### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
`doc/tags` is auto-generated file which shouldn't be managed by git. It was ignored by a [root gitignore rule](https://github.com/rust-lang/rust/blob/master/.gitignore#L79) before, but now the rule hasn't copied into this repo.

[wting/rust.vim](https://github.com/wting/rust.vim) ignores `doc/tags` and there were many PR to make it do. It deserve to be ignored :sunrise: 