### PR TITLE
Fix :Rust* commands

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -175,7 +175,7 @@ function! s:Emit(dict, type, args)
 			silent put =output
 			1
 			d
-			if a:type == "ir"
+			if a:type == "llvm-ir"
 				setl filetype=llvm
 				let extension = 'll'
 			elseif a:type == "asm"

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -34,72 +34,73 @@ endfunction
 " Run {{{1
 
 function! rust#Run(bang, args)
+	let args = s:ShellTokenize(a:args)
 	if a:bang
-		let idx = index(a:args, '--')
+		let idx = index(l:args, '--')
 		if idx != -1
-			let rustc_args = idx == 0 ? [] : a:args[:idx-1]
-			let args = a:args[idx+1:]
+			let rustc_args = idx == 0 ? [] : l:args[:idx-1]
+			let args = l:args[idx+1:]
 		else
-			let rustc_args = a:args
+			let rustc_args = l:args
 			let args = []
 		endif
 	else
 		let rustc_args = []
-		let args = a:args
 	endif
 
-	let b:rust_last_rustc_args = rustc_args
-	let b:rust_last_args = args
+	let b:rust_last_rustc_args = l:rustc_args
+	let b:rust_last_args = l:args
 
 	call s:WithPath(function("s:Run"), rustc_args, args)
 endfunction
 
-function! s:Run(path, rustc_args, args)
-	try
-		let exepath = tempname()
-		if has('win32')
-			let exepath .= '.exe'
-		endif
+function! s:Run(dict, rustc_args, args)
+	let exepath = a:dict.tmpdir.'/'.fnamemodify(a:dict.path, ':t:r')
+	if has('win32')
+		let exepath .= '.exe'
+	endif
 
-		let rustc_args = [a:path, '-o', exepath] + a:rustc_args
+	let rustc_args = [a:dict.path, '-o', exepath] + a:rustc_args
 
-		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
+	let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-		let output = system(shellescape(rustc) . " " . join(map(rustc_args, 'shellescape(v:val)')))
-		if output != ''
-			echohl WarningMsg
-			echo output
-			echohl None
-		endif
-		if !v:shell_error
-			exe '!' . shellescape(exepath) . " " . join(map(a:args, 'shellescape(v:val)'))
-		endif
-	finally
-		if exists("exepath")
-			silent! call delete(exepath)
-		endif
-	endtry
+	let pwd = a:dict.istemp ? a:dict.tmpdir : ''
+	" since we split the input using shell tokenizing rules, we can avoid
+	" escaping it here, as the shell will use the same rules itself.
+	let output = s:system(pwd, shellescape(rustc) . " " . join(rustc_args))
+	if output != ''
+		echohl WarningMsg
+		echo output
+		echohl None
+	endif
+	if !v:shell_error
+		" as before, our args were split using shell tokenizing rules, which
+		" the shell will reapply here
+		exe '!' . shellescape(exepath) . " " . join(a:args)
+	endif
 endfunction
 
 " Expand {{{1
 
 function! rust#Expand(bang, args)
-	if a:bang && !empty(a:args)
-		let pretty = a:args[0]
-		let args = a:args[1:]
+	let args = s:ShellTokenize(a:args)
+	if a:bang && !empty(l:args)
+		let pretty = remove(l:args, 0)
 	else
 		let pretty = "expanded"
-		let args = a:args
 	endif
 	call s:WithPath(function("s:Expand"), pretty, args)
 endfunction
 
-function! s:Expand(path, pretty, args)
+function! s:Expand(dict, pretty, args)
 	try
 		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-		let args = [a:path, '--pretty', a:pretty] + a:args
-		let output = system(shellescape(rustc) . " " . join(map(args, "shellescape(v:val)")))
+		let args = [a:dict.path, '--pretty', a:pretty] + a:args
+		let pwd = a:dict.istemp ? a:dict.tmpdir : ''
+		" since we split the args with shell tokenizing rules, we don't want
+		" to shellescape them here.
+		let output = s:system(pwd, shellescape(rustc) . " " . join(args))
 		if v:shell_error
 			echohl WarningMsg
 			echo output
@@ -113,6 +114,20 @@ function! s:Expand(path, pretty, args)
 			setl buftype=nofile
 			setl bufhidden=hide
 			setl noswapfile
+			" give the buffer a nice name
+			let suffix = 1
+			let basename = fnamemodify(a:dict.path, ':t:r')
+			while 1
+				let bufname = basename
+				if suffix > 1 | let bufname .= ' ('.suffix.')' | endif
+				let bufname .= '.pretty.rs'
+				if bufexists(bufname)
+					let suffix += 1
+					continue
+				endif
+				exe 'silent noautocmd keepalt file' fnameescape(bufname)
+				break
+			endwhile
 		endif
 	endtry
 endfunction
@@ -133,15 +148,19 @@ endfunction
 " Emit {{{1
 
 function! rust#Emit(type, args)
-	call s:WithPath(function("s:Emit"), a:type, a:args)
+	let args = s:ShellTokenize(a:args)
+	call s:WithPath(function("s:Emit"), a:type, args)
 endfunction
 
-function! s:Emit(path, type, args)
+function! s:Emit(dict, type, args)
 	try
 		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-		let args = [a:path, '--emit', a:type, '-o', '-'] + a:args
-		let output = system(shellescape(rustc) . " " . join(map(args, "shellescape(v:val)")))
+		let args = [a:dict.path, '--emit', a:type, '-o', '-'] + a:args
+		let pwd = a:dict.istemp ? a:dict.tmpdir : ''
+		" since we split the args with shell tokenizing rules, we don't want
+		" to shellescape them here
+		let output = s:system(pwd, shellescape(rustc) . " " . join(args))
 		if v:shell_error
 			echohl WarningMsg
 			echo output
@@ -153,52 +172,94 @@ function! s:Emit(path, type, args)
 			d
 			if a:type == "ir"
 				setl filetype=llvm
+				let extension = 'll'
 			elseif a:type == "asm"
 				setl filetype=asm
+				let extension = 's'
 			endif
 			setl buftype=nofile
 			setl bufhidden=hide
 			setl noswapfile
+			if exists('l:extension')
+				" give the buffer a nice name
+				let suffix = 1
+				let basename = fnamemodify(a:dict.path, ':t:r')
+				while 1
+					let bufname = basename
+					if suffix > 1 | let bufname .= ' ('.suffix.')' | endif
+					let bufname .= '.'.extension
+					if bufexists(bufname)
+						let suffix += 1
+						continue
+					endif
+					exe 'silent noautocmd keepalt file' fnameescape(bufname)
+					break
+				endwhile
+			endif
 		endif
 	endtry
 endfunction
 
 " Utility functions {{{1
 
+" Invokes func(dict, ...)
+" Where {dict} is a dictionary with the following keys:
+"   'path' - The path to the file
+"   'tmpdir' - The path to a temporary directory that will be deleted when the
+"              function returns.
+"   'istemp' - 1 if the path is a file inside of {dict.tmpdir} or 0 otherwise.
+" If {istemp} is 1 then an additional key is provided:
+"   'tmpdir_relpath' - The {path} relative to the {tmpdir}.
+"
+" {dict.path} may be a path to a file inside of {dict.tmpdir} or it may be the
+" existing path of the current buffer. If the path is inside of {dict.tmpdir}
+" then it is guaranteed to have a '.rs' extension.
 function! s:WithPath(func, ...)
+	let buf = bufnr('')
+	let saved = {}
+	let dict = {}
 	try
-		let save_write = &write
+		let saved.write = &write
 		set write
-		let path = expand('%')
-		let pathisempty = empty(path)
-		if pathisempty || !save_write
-			" use a temporary file named 'unnamed.rs' inside a temporary
-			" directory. This produces better error messages
-			let tmpdir = tempname()
-			call mkdir(tmpdir)
+		let dict.path = expand('%')
+		let pathisempty = empty(dict.path)
 
-			let save_cwd = getcwd()
-			silent exe 'lcd' fnameescape(tmpdir)
+		" Always create a tmpdir in case the wrapped command wants it
+		let dict.tmpdir = tempname()
+		call mkdir(dict.tmpdir)
 
-			let path = 'unnamed.rs'
+		if pathisempty || !saved.write
+			let dict.istemp = 1
+			" if we're doing this because of nowrite, preserve the filename
+			if !pathisempty
+				let filename = expand('%:t:r').".rs"
+			else
+				let filename = 'unnamed.rs'
+			endif
+			let dict.tmpdir_relpath = filename
+			let dict.path = dict.tmpdir.'/'.filename
 
-			let save_mod = &mod
+			let saved.mod = &mod
 			set nomod
 
-			silent exe 'keepalt write! ' . fnameescape(path)
+			silent exe 'keepalt write! ' . fnameescape(dict.path)
 			if pathisempty
 				silent keepalt 0file
 			endif
 		else
+			let dict.istemp = 0
 			update
 		endif
 
-		call call(a:func, [path] + a:000)
+		call call(a:func, [dict] + a:000)
 	finally
-		if exists("save_mod")   | let &mod = save_mod                    | endif
-		if exists("save_write") | let &write = save_write                | endif
-		if exists("save_cwd")   | silent exe 'lcd' fnameescape(save_cwd) | endif
-		if exists("tmpdir")     | silent call s:RmDir(tmpdir)            | endif
+		if bufexists(buf)
+			for [opt, value] in items(saved)
+				silent call setbufvar(buf, '&'.opt, value)
+				unlet value " avoid variable type mismatches
+			endfor
+		endif
+		if has_key(dict, 'tmpdir') | silent call s:RmDir(dict.tmpdir) | endif
 	endtry
 endfunction
 
@@ -206,6 +267,23 @@ function! rust#AppendCmdLine(text)
 	call setcmdpos(getcmdpos())
 	let cmd = getcmdline() . a:text
 	return cmd
+endfunction
+
+" Tokenize the String according to shell parsing rules
+function! s:ShellTokenize(text)
+	let pat = '\%([^ \t\n''"]\+\|\\.\|''[^'']*\%(''\|$\)\|"\%(\\.\|[^"]\)*\%("\|$\)\)\+'
+	let start = 0
+	let tokens = []
+	while 1
+		let pos = match(a:text, pat, start)
+		if l:pos == -1
+			break
+		endif
+		let end = matchend(a:text, pat, start)
+		call add(tokens, strpart(a:text, pos, end-pos))
+		let start = l:end
+	endwhile
+	return l:tokens
 endfunction
 
 function! s:RmDir(path)
@@ -218,6 +296,16 @@ function! s:RmDir(path)
 		return 0
 	endif
 	silent exe "!rm -rf " . shellescape(a:path)
+endfunction
+
+" Executes {cmd} with the cwd set to {pwd}, without changing Vim's cwd.
+" If {pwd} is the empty string then it doesn't change the cwd.
+function! s:system(pwd, cmd)
+	let cmd = a:cmd
+	if !empty(a:pwd)
+		let cmd = 'cd ' . shellescape(a:pwd) . ' && ' . cmd
+	endif
+	return system(cmd)
 endfunction
 
 " }}}1

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -159,20 +159,23 @@ endfunction
 
 function! s:Emit(dict, type, args)
 	try
+		let output_path = a:dict.tmpdir.'/output'
+
 		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-		let args = [a:dict.path, '--emit', a:type, '-o', '-'] + a:args
+		let args = [a:dict.path, '--emit', a:type, '-o', output_path] + a:args
 		let pwd = a:dict.istemp ? a:dict.tmpdir : ''
 		" since we split the args with shell tokenizing rules, we don't want
 		" to shellescape them here
 		let output = s:system(pwd, shellescape(rustc) . " " . join(args))
-		if v:shell_error
+		if output != ''
 			echohl WarningMsg
 			echo output
 			echohl None
-		else
+		endif
+		if !v:shell_error
 			new
-			silent put =output
+			exe 'silent keepalt read' fnameescape(output_path)
 			1
 			d
 			if a:type == "llvm-ir"

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -60,7 +60,8 @@ function! s:Run(dict, rustc_args, args)
 		let exepath .= '.exe'
 	endif
 
-	let rustc_args = [a:dict.path, '-o', exepath] + a:rustc_args
+	let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
+	let rustc_args = [relpath, '-o', exepath] + a:rustc_args
 
 	let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
@@ -101,7 +102,8 @@ function! s:Expand(dict, pretty, args)
 		else
 			let flag = '--pretty'
 		endif
-		let args = [a:dict.path, '-Z', 'unstable-options', l:flag, a:pretty] + a:args
+		let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
+		let args = [relpath, '-Z', 'unstable-options', l:flag, a:pretty] + a:args
 		let pwd = a:dict.istemp ? a:dict.tmpdir : ''
 		" since we split the args with shell tokenizing rules, we don't want
 		" to shellescape them here.
@@ -163,7 +165,8 @@ function! s:Emit(dict, type, args)
 
 		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-		let args = [a:dict.path, '--emit', a:type, '-o', output_path] + a:args
+		let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
+		let args = [relpath, '--emit', a:type, '-o', output_path] + a:args
 		let pwd = a:dict.istemp ? a:dict.tmpdir : ''
 		" since we split the args with shell tokenizing rules, we don't want
 		" to shellescape them here

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -96,7 +96,12 @@ function! s:Expand(dict, pretty, args)
 	try
 		let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
 
-		let args = [a:dict.path, '--pretty', a:pretty] + a:args
+		if a:pretty =~? '^\%(everybody_loops$\|flowgraph=\)'
+			let flag = '--xpretty'
+		else
+			let flag = '--pretty'
+		endif
+		let args = [a:dict.path, '-Z', 'unstable-options', l:flag, a:pretty] + a:args
 		let pwd = a:dict.istemp ? a:dict.tmpdir : ''
 		" since we split the args with shell tokenizing rules, we don't want
 		" to shellescape them here.
@@ -135,7 +140,7 @@ endfunction
 function! rust#CompleteExpand(lead, line, pos)
 	if a:line[: a:pos-1] =~ '^RustExpand!\s*\S*$'
 		" first argument and it has a !
-		let list = ["normal", "expanded", "typed", "expanded,identified", "flowgraph="]
+		let list = ["normal", "expanded", "typed", "expanded,identified", "flowgraph=", "everybody_loops"]
 		if !empty(a:lead)
 			call filter(list, "v:val[:len(a:lead)-1] == a:lead")
 		endif

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -101,7 +101,7 @@ command! -nargs=* -complete=file -bang -buffer RustRun call rust#Run(<bang>0, <q
 command! -nargs=* -complete=customlist,rust#CompleteExpand -bang -buffer RustExpand call rust#Expand(<bang>0, <q-args>)
 
 " See |:RustEmitIr| for docs
-command! -nargs=* -buffer RustEmitIr call rust#Emit("ir", <q-args>)
+command! -nargs=* -buffer RustEmitIr call rust#Emit("llvm-ir", <q-args>)
 
 " See |:RustEmitAsm| for docs
 command! -nargs=* -buffer RustEmitAsm call rust#Emit("asm", <q-args>)

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -95,16 +95,16 @@ source $VIMRUNTIME/macros/matchit.vim
 " Commands {{{1
 
 " See |:RustRun| for docs
-command! -nargs=* -complete=file -bang -bar -buffer RustRun call rust#Run(<bang>0, [<f-args>])
+command! -nargs=* -complete=file -bang -buffer RustRun call rust#Run(<bang>0, <q-args>)
 
 " See |:RustExpand| for docs
-command! -nargs=* -complete=customlist,rust#CompleteExpand -bang -bar -buffer RustExpand call rust#Expand(<bang>0, [<f-args>])
+command! -nargs=* -complete=customlist,rust#CompleteExpand -bang -buffer RustExpand call rust#Expand(<bang>0, <q-args>)
 
 " See |:RustEmitIr| for docs
-command! -nargs=* -bar -buffer RustEmitIr call rust#Emit("ir", [<f-args>])
+command! -nargs=* -buffer RustEmitIr call rust#Emit("ir", <q-args>)
 
 " See |:RustEmitAsm| for docs
-command! -nargs=* -bar -buffer RustEmitAsm call rust#Emit("asm", [<f-args>])
+command! -nargs=* -buffer RustEmitAsm call rust#Emit("asm", <q-args>)
 
 " Mappings {{{1
 


### PR DESCRIPTION
Fix a number of issues with the `:RustRun`, `:RustExpand`,
`:RustEmitAsm`, and `:RustEmitIr` commands.