### PR TITLE
Replace `be` with `become`

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -56,7 +56,7 @@ syn match rustMacroRepeatCount ".\?[*+]" contained
 syn match rustMacroVariable "$\w\+"
 
 " Reserved (but not yet used) keywords {{{2
-syn keyword   rustReservedKeyword alignof be do offsetof priv pure sizeof typeof unsized yield abstract virtual final override macro
+syn keyword   rustReservedKeyword alignof become do offsetof priv pure sizeof typeof unsized yield abstract virtual final override macro
 
 " Built-in types {{{2
 syn keyword   rustType        isize usize float char bool u8 u16 u32 u64 f32


### PR DESCRIPTION
The reserved keyword `be` has been replaced with `become` by
rust-lang/rust#21918.