### PR TITLE
Include ctags definitions to support Tagbar

### DIFF
--- a/ctags/rust.ctags
+++ b/ctags/rust.ctags
@@ -1,0 +1,11 @@
+--langdef=Rust
+--langmap=Rust:.rs
+--regex-Rust=/^[ \t]*(#\[[^\]]\][ \t]*)*(pub[ \t]+)?(extern[ \t]+)?("[^"]+"[ \t]+)?(unsafe[ \t]+)?fn[ \t]+([a-zA-Z0-9_]+)/\6/f,functions,function definitions/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?type[ \t]+([a-zA-Z0-9_]+)/\2/T,types,type definitions/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?enum[ \t]+([a-zA-Z0-9_]+)/\2/g,enum,enumeration names/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?struct[ \t]+([a-zA-Z0-9_]+)/\2/s,structure names/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?mod[ \t]+([a-zA-Z0-9_]+)/\2/m,modules,module names/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?static[ \t]+([a-zA-Z0-9_]+)/\2/c,consts,static constants/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?trait[ \t]+([a-zA-Z0-9_]+)/\2/t,traits,traits/
+--regex-Rust=/^[ \t]*(pub[ \t]+)?impl([ \t\n]*<[^>]*>)?[ \t]+(([a-zA-Z0-9_:]+)[ \t]*(<[^>]*>)?[ \t]+(for)[ \t]+)?([a-zA-Z0-9_]+)/\4 \6 \7/i,impls,trait implementations/
+--regex-Rust=/^[ \t]*macro_rules![ \t]+([a-zA-Z0-9_]+)/\1/d,macros,macro definitions/

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -81,6 +81,20 @@ g:rust_bang_comment_leader~
 	    let g:rust_bang_comment_leader = 1
 <
 
+                                               *g:rust_use_builtin_ctags_defs*
+g:rust_use_builtin_ctags_defs~
+	Set this option to 0 if you have customized ctags definitions for Rust
+	and do not wish for those included with rust.vim to be used: >
+	    let g:rust_use_builtin_ctags_defs = 0
+<
+	Note that rust.vim's built-in definitions are only used for the Tagbar
+	Vim plugin, if you have it installed--it is not automatically used
+	when generating |tags| files that Vim can use to navigate to
+	definitions across different source files. Feel free to copy
+	`rust.vim/ctags/rust.ctags` into your own `~/.ctags` if you wish to
+	generate |tags| files.
+
+
                                                  *g:ftplugin_rust_source_path*
 g:ftplugin_rust_source_path~
 	Set this option to a path that should be prepended to 'path' for Rust

--- a/ftplugin/rust/tagbar.vim
+++ b/ftplugin/rust/tagbar.vim
@@ -1,0 +1,32 @@
+"
+" Support for Tagbar -- https://github.com/majutsushi/tagbar
+"
+if !exists(':Tagbar')
+  finish
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+let g:tagbar_type_rust = {
+  \ 'ctagstype' : 'rust',
+  \ 'kinds' : [
+    \'T:types',
+    \'f:functions',
+    \'g:enumerations',
+    \'s:structures',
+    \'m:modules',
+    \'c:constants',
+    \'t:traits',
+    \'i:trait implementations',
+  \ ]
+\ }
+
+" In case you've updated/customized your ~/.ctags and prefer to use it.
+if get(g:, 'rust_use_builtin_ctags_defs', 1)
+  let g:tagbar_type_rust.deffile = expand('<sfile>:p:h:h:h') . '/ctags/rust.ctags'
+endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+


### PR DESCRIPTION
If the popular [Tagbar](https://github.com/majutsushi/tagbar) plugin is in use, set it up with the necessary settings to support Rust.
