### PR TITLE
update install with NeoBundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ details.
 ### Using [NeoBundle][nb]
 
 1. Add `NeoBundle 'rust-lang/rust.vim'` to `~/.vimrc`
-2. Re-open vim or execute `:NeoBundleInstall`
+2. Re-open vim or execute `:source ~/.vimrc`


### PR DESCRIPTION
When I execute `:NeoBundleInstall`, I got: 

    [neobundle/install] You may have used the wrong bundle name, or all of the bundles are already installed.