### PR TITLE
Add match and else to the keywords

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -23,7 +23,7 @@ syn keyword   rustKeyword     box nextgroup=rustBoxPlacement skipwhite skipempty
 syn keyword   rustKeyword     continue
 syn keyword   rustKeyword     extern nextgroup=rustExternCrate,rustObsoleteExternMod skipwhite skipempty
 syn keyword   rustKeyword     fn nextgroup=rustFuncName skipwhite skipempty
-syn keyword   rustKeyword     for in if impl let
+syn keyword   rustKeyword     for in match if else impl let
 syn keyword   rustKeyword     loop pub
 syn keyword   rustKeyword     return super
 syn keyword   rustKeyword     unsafe where while


### PR DESCRIPTION
The `match` and `else` keywords are currently missing proper highlighting.


Regards,
Ivan