### PR TITLE
Make boolean settings more reasonable

### DIFF
--- a/after/syntax/rust.vim
+++ b/after/syntax/rust.vim
@@ -1,9 +1,9 @@
-if !exists('g:rust_conceal') || !has('conceal') || &enc != 'utf-8'
+if !exists('g:rust_conceal') || g:rust_conceal == 0 || !has('conceal') || &enc != 'utf-8'
 	finish
 endif
 
 " For those who don't want to see `::`...
-if exists('g:rust_conceal_mod_path')
+if exists('g:rust_conceal_mod_path') && g:rust_conceal_mod_path != 0
 	syn match rustNiceOperator "::" conceal cchar=ㆍ
 endif
 
@@ -18,7 +18,7 @@ syn match rustNiceOperator "=>" contains=rustFatRightArrowHead,rustFatRightArrow
 syn match rustNiceOperator /\<\@!_\(_*\>\)\@=/ conceal cchar=′
 
 " For those who don't want to see `pub`...
-if exists('g:rust_conceal_pub')
+if exists('g:rust_conceal_pub') && g:rust_conceal_pub != 0
     syn match rustPublicSigil contained "pu" conceal cchar=＊
     syn match rustPublicRest contained "b" conceal cchar= 
     syn match rustNiceOperator "pub " contains=rustPublicSigil,rustPublicRest
@@ -26,6 +26,6 @@ endif
 
 hi link rustNiceOperator Operator
 
-if !exists('g:rust_conceal_mod_path')
+if !exists('g:rust_conceal_mod_path') && g:rust_conceal_mod_path != 0
     hi! link Conceal Operator
 endif

--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -15,7 +15,7 @@ if exists(":CompilerSet") != 2
 	command -nargs=* CompilerSet setlocal <args>
 endif
 
-if exists("g:rustc_makeprg_no_percent") && g:rustc_makeprg_no_percent == 1
+if exists("g:rustc_makeprg_no_percent") && g:rustc_makeprg_no_percent != 0
 	CompilerSet makeprg=rustc
 else
 	CompilerSet makeprg=rustc\ \%

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -18,7 +18,7 @@ set cpo&vim
 " comments, so we'll use that as our default, but make it easy to switch.
 " This does not affect indentation at all (I tested it with and without
 " leader), merely whether a leader is inserted by default or not.
-if exists("g:rust_bang_comment_leader") && g:rust_bang_comment_leader == 1
+if exists("g:rust_bang_comment_leader") && g:rust_bang_comment_leader != 0
 	" Why is the `,s0:/*,mb:\ ,ex:*/` there, you ask? I don't understand why,
 	" but without it, */ gets indented one space even if there were no
 	" leaders. I'm fairly sure that's a Vim bug.
@@ -35,7 +35,7 @@ silent! setlocal formatoptions+=j
 " otherwise it's better than nothing.
 setlocal smartindent nocindent
 
-if !exists("g:rust_recommended_style") || g:rust_recommended_style == 1
+if !exists("g:rust_recommended_style") || g:rust_recommended_style != 0
 	setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab
 	setlocal textwidth=99
 endif
@@ -67,7 +67,7 @@ if has("folding") && exists('g:rust_fold') && g:rust_fold != 0
 	endif
 endif
 
-if has('conceal') && exists('g:rust_conceal')
+if has('conceal') && exists('g:rust_conceal') && g:rust_conceal != 0
 	let b:rust_set_conceallevel=1
 	setlocal conceallevel=2
 endif


### PR DESCRIPTION
Currently, only the existence of some of the boolean settings the users can set in their .vimrc are checked, not the actual value of the variable. That means that `let g:rust_conceal = 0` would actually switch on concealing. That's very unintuitive. This PR corrects that.