### PR TITLE
Add check for matchit being loaded

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -90,7 +90,9 @@ set matchpairs+=<:>
 " highlighting perspective (built into Vim), but the actual % functionality
 " can be fixed by this use of matchit.vim.
 let b:match_skip = 's:comment\|string\|rustArrow'
-source $VIMRUNTIME/macros/matchit.vim
+if !exists("loaded_matchit")
+	source $VIMRUNTIME/macros/matchit.vim
+endif
 
 " Commands {{{1
 


### PR DESCRIPTION
This prevents matchit from being loaded again if it is already loaded, which is currently the case for NeoVim users as it is now included by default in the current release and the file is not where the rust plugin will expect matchit to be. This was changed [around here](https://github.com/neovim/neovim/commit/98053f0f9fc3405e48ba3a9089a29fd23b3b414c) in Neovim.

It should resolve rust-lang/rust.vim#38