### PR TITLE
Integrate with rustfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git clone --depth=1 https://github.com/rust-lang/rust.vim.git ~/.vim/bundle/rust
 ## Enabling autoformat
 
 This plugin can optionally format your code using [rustfmt][rfmt] every time a
-buffer is written. Simple put `let g:rust_fmt_autosave = 1` in your `.vimrc`.
+buffer is written. Simple put `let g:rustfmt_autosave = 1` in your `.vimrc`.
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ git clone --depth=1 https://github.com/rust-lang/rust.vim.git ~/.vim/bundle/rust
 
 This plugin can optionally format your code using [rustfmt][rfmt] every time a
 buffer is written. Simple put `let g:rust_fmt_autosave = 1` in your `.vimrc`.
+
+## Help
+
+Further help can be found in the documentation with `:help rust`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This is a vim plugin that provides [Rust][r] file detection and syntax highlighting.
+This is a vim plugin that provides [Rust][r] file detection, syntax highlighting, and (optional) autoformatting.
 
 ## Installation
 
@@ -31,3 +31,8 @@ git clone --depth=1 https://github.com/rust-lang/rust.vim.git ~/.vim/bundle/rust
 
 1. Add `NeoBundle 'rust-lang/rust.vim'` to `~/.vimrc`
 2. Re-open vim or execute `:source ~/.vimrc`
+
+## Enabling autoformat
+
+This plugin can optionally format your code using [rustfmt][rfmt] every time a
+buffer is written. Simple put `let g:rust_fmt_autosave = 1` in your `.vimrc`.

--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -42,7 +42,7 @@ function! rustfmt#Format()
     " clobbering other additions
     if s:got_fmt_error
       let s:got_fmt_error = 0
-      call setloclist([])
+      call setloclist(0, [])
       lwindow
     endif
   elseif g:rustfmt_fail_silently == 0
@@ -67,7 +67,7 @@ function! rustfmt#Format()
     endif
 
     if !empty(errors)
-      call setloclist(errors, 'r')
+      call setloclist(0, errors, 'r')
       echohl Error | echomsg "rustfmt returned error" | echohl None
     endif
 

--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -1,7 +1,6 @@
-" WTF License
-" Author: stephen@stephensugden.com
+" Author: Stephen Sugden <stephen@stephensugden.com>
 "
-" Directly based on the go#fmt#Format plugin from fatih/vim-go
+" Adapted from https://github.com/fatih/vim-go
 
 if !exists("g:rustfmt_autosave")
   let g:rustfmt_autosave = 0

--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -57,8 +57,6 @@ function! rustfmt#Format()
                          \"lnum":     tokens[2],
                          \"col":      tokens[3],
                          \"text":     tokens[5]})
-      else
-        echo line
       endif
     endfor
 

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -88,11 +88,37 @@ g:ftplugin_rust_source_path~
 	    let g:ftplugin_rust_source_path = $HOME.'/dev/rust'
 <
 
-                                                       *g:cargo_manifest_name*
+                                                      *g:cargo_manifest_name*
 g:cargo_manifest_name~
 	Set this option to the name of the manifest file for your projects. If
 	not specified it defaults to 'Cargo.toml' : >
-	    let g:cargo_manifest_name = 'Cargo.toml'
+	        let g:cargo_manifest_name = 'Cargo.toml'
+<
+
+                                                       *g:rustfmt_command*
+g:rustfmt_command~
+	Set this option to the name of the 'rustfmt' executable in your $PATH. If
+	not specified it defaults to 'rustfmt' : >
+	    let g:rustfmt_command = 'rustfmt'
+<
+                                                       *g:rustfmt_autosave*
+g:rustfmt_autosave~
+	Set this option to 1 to run |:RustFmt| automatically when saving a
+	buffer. If not specified it defaults to 0 : >
+	    let g:rustfmt_autosave = 0
+<
+                                                       *g:rustfmt_fail_silently*
+g:rustfmt_fail_silently~
+	Set this option to 1 to prevent 'rustfmt' from populating the
+	|location-list| with errors. If not specified it defaults to 0: >
+	    let g:rustfmt_fail_silently = 0
+<
+                                                       *g:rustfmt_options*
+g:rustfmt_options~
+	Set this option to a string of options to pass to 'rustfmt'. The
+	write-mode is already set to 'overwrite'. If not specified it 
+	defaults to '' : >
+	    let g:rustmft_options = ''
 <
 
                                                           *g:rust_playpen_url*
@@ -183,6 +209,15 @@ COMMANDS                                                       *rust-commands*
 		|g:rust_shortener_url| is the base url for the shorterner, by
 		default "https://is.gd/"
 
+:RustFmt                                                       *:RustFmt*
+		Runs |g:rustfmt_command| on the current buffer. If
+		|g:rustfmt_options| is set then those will be passed to the
+		executable.
+
+		If |g:rustfmt_fail_silently| is 0 (the default) then it
+		will populate the |location-list| with the errors from
+		|g:rustfmt_command|. If |g:rustfmt_fail_silently| is set to 1
+		then it will not populate the |location-list|.
 
 ==============================================================================
 MAPPINGS                                                       *rust-mappings*

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -109,6 +109,9 @@ command! -nargs=* -buffer RustEmitAsm call rust#Emit("asm", <q-args>)
 " See |:RustPlay| for docs
 command! -range=% RustPlay :call rust#Play(<count>, <line1>, <line2>, <f-args>)
 
+" See |:RustFmt| for docs
+command! -buffer RustFmt call rustfmt#Format()
+
 " Mappings {{{1
 
 " Bind ⌘R in MacVim to :RustRun

--- a/plugin/rustfmt.vim
+++ b/plugin/rustfmt.vim
@@ -1,6 +1,8 @@
 augroup rustfmt
+  autocmd!
+
   " code formatting on save
-  if get(g:, "rustfmt_autosave", 1)
+  if get(g:, "rustfmt_autosave", 0)
     autocmd BufWritePre *.rs call rustfmt#Format()
   endif
 augroup END

--- a/plugin/rustfmt.vim
+++ b/plugin/rustfmt.vim
@@ -1,0 +1,6 @@
+augroup rustfmt
+  " code formatting on save
+  if get(g:, "rustfmt_autosave", 1)
+    autocmd BufWritePre *.rs call rustfmt#Format()
+  endif
+augroup END


### PR DESCRIPTION
I took #49 and ran with it a bit as I want to get this over the line.

Differences:

* New `RustFmt` command
* We fill the location-list rather than the quickfix-list, due to location-list and `RustFmt` itself being buffer-local.
* No more echo'ing of unparseable errors.
* Documentation.
* Misc code cleanup; safety.

Will also fix #43.

Thoughts @steveklabnik, @grncdr?