### PR TITLE
Fix for screen redrawing issue in RustRun etc.

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -346,7 +346,7 @@ function! s:RmDir(path)
 		echoerr 'Attempted to delete protected path: ' . a:path
 		return 0
 	endif
-	silent exe "!rm -rf " . shellescape(a:path)
+	return system("rm -rf " . shellescape(a:path))
 endfunction
 
 " Executes {cmd} with the cwd set to {pwd}, without changing Vim's cwd.


### PR DESCRIPTION
`:RustRun` etc. would cause buggy screen redrawing in the error case. Tracked down the issue to a helper function.

I'm not particularly happy about the structure of this functionality. I'd prefer we went through cargo and appropriately handled errors in the quickfix list instead of echohl'ing it out (similar to how we're handling errors in `:RustFmt`) . I'll stick that on my TODO list. (see: #27)

Fixes #22.