### PR TITLE
Fix check for g:rust_conceal_mod_path in after/syntax/rust.vim

### DIFF
--- a/after/syntax/rust.vim
+++ b/after/syntax/rust.vim
@@ -26,6 +26,6 @@ endif
 
 hi link rustNiceOperator Operator
 
-if !exists('g:rust_conceal_mod_path') && g:rust_conceal_mod_path != 0
+if !(exists('g:rust_conceal_mod_path') && g:rust_conceal_mod_path != 0)
     hi! link Conceal Operator
 endif


### PR DESCRIPTION
The previous check was quite broken. If `g:rust_conceal_mod_path` wasn't
set, it would throw an error. If it was set to `0`, it would incorrectly
skip linking the highlight groups. It only worked properly for the case
where `g:rust_conceal_mod_path` was set to a non-zero value.