### PR TITLE
Don't accept unicode escapes without curly braces.

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -125,7 +125,6 @@ syn match     rustMacro       '#\w\(\w\)*' contains=rustAssert,rustPanic
 
 syn match     rustEscapeError   display contained /\\./
 syn match     rustEscape        display contained /\\\([nrt0\\'"]\|x\x\{2}\)/
-syn match     rustEscapeUnicode display contained /\\\(u\x\{4}\|U\x\{8}\)/
 syn match     rustEscapeUnicode display contained /\\u{\x\{1,6}}/
 syn match     rustStringContinuation display contained /\\\n\s*/
 syn region    rustString      start=+b"+ skip=+\\\\\|\\"+ end=+"+ contains=rustEscape,rustEscapeError,rustStringContinuation


### PR DESCRIPTION
At least with Rust 1.5, putting a 4-digit Unicode escape into a string literal produces an error message:

    src/cells.rs:81:19: 81:21 error: incorrect unicode escape sequence
    src/cells.rs:81             (1, "e\u0301"),
				      ^~
    src/cells.rs:81:19: 81:21 help: format of unicode escape sequences is `\u{…}`
    src/cells.rs:81             (1, "e\u0301"),

...and a six-digit Unicode escape (`\Uxxxxxx`) just produces:

    src/cells.rs:81:20: 81:21 error: unknown character escape: U

The only supported Unicode escape sequence is `\u` followed by hex digits in curly braces, so that's the only format the Vim syntax highlighting should accept.