### PR TITLE
Use system instead of systemlist for backwards compatibility.

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -27,7 +27,7 @@ function! rustfmt#Format()
 
   let command = g:rustfmt_command . " --write-mode=overwrite "
 
-  let out = systemlist(command . g:rustfmt_options . " " . shellescape(l:tmpname))
+  let out = split(system(command . g:rustfmt_options . " " . shellescape(l:tmpname)), '\n')
 
   if v:shell_error == 0
     " remove undo point caused via BufWritePre

--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -27,7 +27,7 @@ function! rustfmt#Format()
 
   let command = g:rustfmt_command . " --write-mode=overwrite "
 
-  let out = split(system(command . g:rustfmt_options . " " . shellescape(l:tmpname)), '\n')
+  let out = split(system(command . g:rustfmt_options . " " . shellescape(l:tmpname)), '(\n|\rn)$')
 
   if v:shell_error == 0
     " remove undo point caused via BufWritePre


### PR DESCRIPTION
Systemlist is not available in some versions of vim.  