### PR TITLE
Syntax check rust with -Zno-trans instead of -Zparse-only

### DIFF
--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -14,7 +14,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_rust_rustc_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args': '-Zparse-only' })
+    let makeprg = self.makeprgBuild({
+        \ 'args': 'rustc -Zno-trans',
+        \ 'fname': '' })
 
     let errorformat  =
         \ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
@@ -28,6 +30,7 @@ function! SyntaxCheckers_rust_rustc_GetLocList() dict
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'exec': 'cargo',
     \ 'filetype': 'rust',
     \ 'name': 'rustc'})
 


### PR DESCRIPTION
Only parsing missed a lot of errors. This PR changes so more steps of the compile is executed and more errors are found. The solution required some extra code to detect if we are in a standalone rs file or inside a crate since that affected if I could use `crate rustc -Zno-trans` or `rustc -Zno-trans`

Fixes #67 
