### PR TITLE
Improved syntastic linting

### DIFF
--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -133,6 +133,31 @@ g:rust_shortener_url~
 	    let g:rust_shortener_url = 'https://is.gd/'
 <
 
+							*g:rustc_syntax_only*
+g:rustc_syntax_only~
+	Set this option to control the syntastic linter.
+	You can choose between a simple syntax parser or a fuller compilation.
+
+	The syntax parser is very fast, but won't catch any compilation
+	errors. This is the default.
+	We recommend you enable syntastic's active mode with this setting
+	(that's the default too).  >
+	let g:rustc_syntax_only = 1
+<
+	
+	The fuller compilation performs a compilation of the entire project.
+	This makes it really slow on large projects.
+	If VIM becomes unusable, set syntastic passive mode for Rust. This
+	will make it so that the lint will only run on |:SyntasticCheck| (see
+	|syntastic_mode_map|).
+>
+	let g:rustc_syntax_only = 0
+	" Syntastic passive mode
+	let g:syntastic_mode_map = {
+		\ "mode": "active",
+		\ "active_filetypes": [],
+		\ "passive_filetypes": ["rust"] }
+<
 
 ==============================================================================
 COMMANDS                                                       *rust-commands*

--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -10,23 +10,28 @@ if exists("g:loaded_syntastic_rust_rustc_checker")
 endif
 let g:loaded_syntastic_rust_rustc_checker = 1
 
+if !exists('g:rustc_syntax_only')
+    let g:rustc_syntax_only = 1 "Keep the fast behaviour by default
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_rust_rustc_GetLocList() dict
+    let compiler_params = g:rustc_syntax_only ? '-Zparse-only' : '-Zno-trans'
     let cwd = '.' " Don't change cwd as default
     let cargo_toml_path = findfile('Cargo.toml', '.;')
     if empty(cargo_toml_path) " Plain rs file, not a crate
         let makeprg = self.makeprgBuild({
             \ 'exe': 'rustc',
-            \ 'args': '-Zno-trans' })
+            \ 'args': compiler_params})
     else " We are inside a crate
         let makeprg = self.makeprgBuild({
             \ 'exe': 'cargo',
-            \ 'args': 'rustc -Zno-trans',
+            \ 'args': 'rustc ' . compiler_params,
             \ 'fname': '' })
         " Change cwd to the root of the crate
-        let cwd = fnamemodify( cargo_toml_path, ':p:h') 
+        let cwd = fnamemodify( cargo_toml_path, ':p:h')
     endif
 
     let errorformat  =

--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -14,7 +14,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_rust_rustc_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args': '-Zparse-only' })
+    let makeprg = self.makeprgBuild({
+        \ 'args': 'rustc -Zno-trans',
+        \ 'fname': '' })
 
     let errorformat  =
         \ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
@@ -28,6 +30,7 @@ function! SyntaxCheckers_rust_rustc_GetLocList() dict
 endfunction
 
 call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'exec': 'cargo',
     \ 'filetype': 'rust',
     \ 'name': 'rustc'})
 


### PR DESCRIPTION
This PR builds on PR #72 .

There's a new option to choose between fast lint (parse-only) or comprehensive (no-trans). You can change this at runtime too.

Possible improvements include a buffer-local variable so that you can have different projects with different linting levels.
