### PR TITLE
Added errorformat line: ignore 'Compiling...'

### DIFF
--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -27,6 +27,8 @@ function! s:is_absolute(path)
     return a:path[0] == '/' || a:path =~ '[A-Z]\+:'
 endfunction
 
+CompilerSet errorformat+=%-G%\\s%#Compiling%.%#
+
 let s:local_manifest = findfile(s:cargo_manifest_name, '.;')
 if s:local_manifest != ''
     let s:local_manifest = fnamemodify(s:local_manifest, ':p:h').'/'


### PR DESCRIPTION
The motivation here was that `:make build` didn't jump immediately to the first error because of Cargo's "Compiling <file>..." line. Ignoring that takes us right to what needs fixing.