### PR TITLE
Support rustfmt 0.5.0 exit codes.

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -29,7 +29,7 @@ function! rustfmt#Format()
 
   let out = systemlist(command . g:rustfmt_options . " " . shellescape(l:tmpname))
 
-  if v:shell_error == 0
+  if v:shell_error == 0 || v:shell_error == 3
     " remove undo point caused via BufWritePre
     try | silent undojoin | catch | endtry
 


### PR DESCRIPTION
Hello vimers,

This change updates the acceptable exit codes from `rustfmt` when deciding whether or not to write back the file or display the errors location list.

As of rust-lang-nursery/rustfmt#923, `rustfmt` exits with either a 0, 1, 2, or 3 depending on what happened. Prior to this upstream change, `rustfmt` would exit 0 when issues that cannot be automatically resolved would occur. Now, the same errors (such as "line exceeded maximum length") result in an exit of 3 (see the [README](line exceeded maximum length) for more details).

This change will treat an exit of 3 as "okay" for writing back as `rustfmt` didn't fail (it just couldn't auto-format a nicer solution).

Closes #68
Closes #75
References rust-lang-nursery/rustfmt#923

![gif-keyboard-6579402489401314324](https://cloud.githubusercontent.com/assets/261548/15662087/a91316f6-26aa-11e6-930e-c9596456dbb2.gif)
