### PR TITLE
Fix ftdetect issue

### DIFF
--- a/ftdetect/rust.vim
+++ b/ftdetect/rust.vim
@@ -1,1 +1,4 @@
-au BufRead,BufNewFile *.rs set filetype=rust
+augroup rust_ftdetect
+  au!
+  au BufRead,BufNewFile *.rs set filetype=rust
+augroup END


### PR DESCRIPTION
vim can not detect rust filetype, it is due to local runtime has autocmd for `*.rs`, so we should use augroup, and `au!` to clean up autocmd for `*.rs`.

and here is verbose log
```
:Verbose au BufRead,BufNewFile *.rs --- Auto-Commands --- filetypedetect BufReadPost *.rs setf hercules Last set from /usr/local/share/nvim/runtime/filetype.vim
BufReadPost
    *.rs      set filetype=rust
    Last set from ~/.cache/vimfiles/.dein/ftdetect/ftdetect.vim
filetypedetect  BufNewFile
    *.rs      setf hercules
    Last set from /usr/local/share/nvim/runtime/filetype.vim
BufNewFile
    *.rs      set filetype=rust
    Last set from ~/.cache/vimfiles/.dein/ftdetect/ftdetect.vim
```