### PR TITLE
Fix issue with delimitMate/vim-plug (fix #48)

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -2,7 +2,7 @@
 " Description:  Vim syntax file for Rust
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
 " Maintainer:   Kevin Ballard <kevin@sb.org>
-" Last Change:  January 29, 2015
+" Last Change:  June 08, 2016
 
 if exists("b:did_ftplugin")
 	finish
@@ -11,6 +11,9 @@ let b:did_ftplugin = 1
 
 let s:save_cpo = &cpo
 set cpo&vim
+
+augroup rust.vim
+autocmd!
 
 " Variables {{{1
 
@@ -54,7 +57,33 @@ if exists("g:loaded_delimitMate")
 	if exists("b:delimitMate_excluded_regions")
 		let b:rust_original_delimitMate_excluded_regions = b:delimitMate_excluded_regions
 	endif
-	let b:delimitMate_excluded_regions = delimitMate#Get("excluded_regions") . ',rustLifetimeCandidate,rustGenericLifetimeCandidate'
+
+	let s:delimitMate_extra_excluded_regions = ',rustLifetimeCandidate,rustGenericLifetimeCandidate'
+
+	" For this buffer, when delimitMate issues the `User delimitMate_map`
+	" event in the autocommand system, add the above-defined extra excluded
+	" regions to delimitMate's state, if they have not already been added.
+	autocmd User <buffer>
+		\ if expand('<afile>') ==# 'delimitMate_map' && match(
+		\     delimitMate#Get("excluded_regions"),
+		\     s:delimitMate_extra_excluded_regions) == -1
+		\|  let b:delimitMate_excluded_regions =
+		\       delimitMate#Get("excluded_regions")
+		\       . s:delimitMate_extra_excluded_regions
+		\|endif
+
+	" For this buffer, when delimitMate issues the `User delimitMate_unmap`
+	" event in the autocommand system, delete the above-defined extra excluded
+	" regions from delimitMate's state (the deletion being idempotent and
+	" having no effect if the extra excluded regions are not present in the
+	" targeted part of delimitMate's state).
+	autocmd User <buffer>
+		\ if expand('<afile>') ==# 'delimitMate_unmap'
+		\|  let b:delimitMate_excluded_regions = substitute(
+		\       delimitMate#Get("excluded_regions"),
+		\       '\C\V' . s:delimitMate_extra_excluded_regions,
+		\       '', 'g')
+		\|endif
 endif
 
 if has("folding") && exists('g:rust_fold') && g:rust_fold != 0
@@ -159,9 +188,12 @@ let b:undo_ftplugin = "
 		\|ounmap <buffer> ]]
 		\|set matchpairs-=<:>
 		\|unlet b:match_skip
+		\|augroup! rust.vim
 		\"
 
 " }}}1
+
+augroup END
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Fix the issue reported in [GitHub issue ticket #48], whereby, if one —

  - used [vim-plug] to load rust.vim, using vim-plug's `'for'` option to
    only load rust.vim for buffers with `filetype=rust`, and also
  - used [delimitMate]

— an error message would be produced each time one opened a new Rust
buffer.

This error was apparently caused by rust.vim, under the afore-described
conditions, calling into delimitMate (apparently to advise it not to
treat the U+0027 APOSTROPHE characters in Rust's lifetime syntax as
single quotation marks to be automatically closed) before the latter
plug-in had completed its necessary initialization, causing delimitMate
to overconfidently attempt to access as-yet-uninitialized internal
state, raising the error with whose aforementioned message this chain of
events would result in the user being unceremoniously presented.

This commit attempts to fix this issue by moving rust.vim's call into
delimitMate into a buffer-local autocommand set to run when delimitMate
issues the `User delimitMate_map` event in the autocommand system, which
event delimitMate thus issues to signal that it has reached —
disregarding the particulars — a stage in its initialization at which it
would be appropriate for other plug-ins to interface with it.

In short, by letting delimitMate tell rust.vim when the former is ready
to be interfaced with, and only then interfacing with it, this commit
allows rust.vim to avoid the afore-described error-raising case of
interfacing with delimitMate when the latter is not thus ready.

This commit also sets a buffer-local autocommand to run when delimitMate
issues the `User delimitMate_unmap` event in the autocommand system,
which autocommand is to clean up after the modifications of
delimitMate's state made by the aforementioned `User delimitMate_map`
autocommand.

Furthermore, this commit adds `augroup`, `autocmd!`, and `augroup!`
commands as necessary and proper in attempting to make its use of
autocommands adhere to norms, propriety, and idioms recommended in the
documentation of the autocommand system.

Additionally, this commit updates the "Last Change" date listed at the
top of the script that it modifies to reflect its modification.

The changes made in this commit appear to fix the afore-described issue
for [me], and do not, to my knowledge, introduce any untoward behavior;
however, this fix has not, to my knowledge, been tested by anyone else.

I affirm that the changes made in this commit are based solely on —

  - the existing script that these changes change;
  - the public documentation of Vim;
  - the public documentation of delimitMate; and
  - comments on [GitHub issue ticket #48];

— and not on any other software or other work.

I publish these changes under the same licensing terms as those under
which rust.vim in general is published at this time (2016-06-08), i.e.,
dual-licensed under the MIT and Apache-2.0 licences.

Fixes #48.

[GitHub issue ticket #48]: <https://github.com/rust-lang/rust.vim/issues/48>
[vim-plug]: <https://github.com/junegunn/vim-plug>
[delimitMate]: <https://github.com/Raimondi/delimitMate>
[me]: <https://github.com/8573>