### PR TITLE
Fix incorrect indent on new match arms

### DIFF
--- a/indent/rust.vim
+++ b/indent/rust.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:         Rust
 " Author:           Chris Morgan <me@chrismorgan.info>
-" Last Change:      2014 Sep 13
+" Last Change:      2016 Jul 15
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -132,6 +132,7 @@ function GetRustIndent(lnum)
 				\ && s:get_line_trimmed(a:lnum) !~ '^\s*[\[\]{}]'
 				\ && prevline !~ '^\s*fn\s'
 				\ && prevline !~ '([^()]\+,$'
+				\ && s:get_line_trimmed(a:lnum) !~ '^\s*\S\+\s*=>'
 		" Oh ho! The previous line ended in a comma! I bet cindent will try to
 		" take this too far... For now, let's normally use the previous line's
 		" indent.
@@ -155,6 +156,8 @@ function GetRustIndent(lnum)
 		"
 		" if baz && (foo ||
 		"            bar) {
+		"
+		" Another case is when the current line is a new match arm.
 		"
 		" There are probably other cases where we don't want to do this as
 		" well. Add them as needed.


### PR DESCRIPTION
This adds another case where if the previous line ends on a comma and
the current line is a new match arm, then we *don't* use the previous
line's indentation.

For example consider

```
match x {
    a => f(0,
           1),
    b => ...
}
```

which would previously be indented as

```
match x {
    a => f(0,
           1),
           b => ...
}
```