### PR TITLE
Move rustfmt_autosave to ftplugin

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -193,6 +193,11 @@ let b:undo_ftplugin = "
 
 " }}}1
 
+" Code formatting on save
+if get(g:, "rustfmt_autosave", 0)
+	autocmd BufWritePre *.rs call rustfmt#Format()
+endif
+
 augroup END
 
 let &cpo = s:save_cpo

--- a/plugin/rustfmt.vim
+++ b/plugin/rustfmt.vim
@@ -1,8 +1,0 @@
-augroup rustfmt
-  autocmd!
-
-  " code formatting on save
-  if get(g:, "rustfmt_autosave", 0)
-    autocmd BufWritePre *.rs call rustfmt#Format()
-  endif
-augroup END


### PR DESCRIPTION
It doesn't need to be in the `plugin` folder because the autocommand only needs to be set when a Rust file is loaded. Only things that need to run when Vim starts should go in the `plugin` folder. Everything else can be put in `ftplugin`.

Behavior should be the same except that it picks up the value of `g:rustfmt_autosave` later than it did before. This is how most other plugins behave.