### PR TITLE
Add support for new error format

### DIFF
--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -27,7 +27,10 @@ function! s:is_absolute(path)
     return a:path[0] == '/' || a:path =~ '[A-Z]\+:'
 endfunction
 
-CompilerSet errorformat+=%-G%\\s%#Compiling%.%#
+" Ignore general cargo progress messages
+CompilerSet errorformat+=
+			\%-G%\\s%#Downloading%.%#,
+			\%-G%\\s%#Compiling%.%#
 
 let s:local_manifest = findfile(s:cargo_manifest_name, '.;')
 if s:local_manifest != ''

--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -30,7 +30,8 @@ endfunction
 " Ignore general cargo progress messages
 CompilerSet errorformat+=
 			\%-G%\\s%#Downloading%.%#,
-			\%-G%\\s%#Compiling%.%#
+			\%-G%\\s%#Compiling%.%#,
+			\%-G%\\s%#Finished%.%#
 
 let s:local_manifest = findfile(s:cargo_manifest_name, '.;')
 if s:local_manifest != ''

--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -31,7 +31,9 @@ endfunction
 CompilerSet errorformat+=
 			\%-G%\\s%#Downloading%.%#,
 			\%-G%\\s%#Compiling%.%#,
-			\%-G%\\s%#Finished%.%#
+			\%-G%\\s%#Finished%.%#,
+			\%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
+			\%-G%\\s%#To\ learn\ more\\,%.%#
 
 let s:local_manifest = findfile(s:cargo_manifest_name, '.;')
 if s:local_manifest != ''

--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -39,8 +39,7 @@ CompilerSet errorformat+=
 			\%Eerror[E%n]:\ %m,
 			\%Wwarning:\ %m,
 			\%Inote:\ %m,
-			\%C\ %#-->\ %f:%l:%c,
-			\%C%*[0-9\ ]\|%.%#
+			\%C\ %#-->\ %f:%l:%c
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -21,6 +21,7 @@ else
 	CompilerSet makeprg=rustc\ \%
 endif
 
+" Old errorformat (before nightly 2016/08/10)
 CompilerSet errorformat=
 			\%f:%l:%c:\ %t%*[^:]:\ %m,
 			\%f:%l:%c:\ %*\\d:%*\\d\ %t%*[^:]:\ %m,
@@ -28,6 +29,15 @@ CompilerSet errorformat=
 			\%-G%*[\ ]^,
 			\%-G%*[\ ]^%*[~],
 			\%-G%*[\ ]...
+
+" New errorformat (after nightly 2016/08/10)
+CompilerSet errorformat+=
+			\%Eerror:\ %m,
+			\%Eerror[E%n]:\ %m,
+			\%Wwarning:\ %m,
+			\%Inote:\ %m,
+			\%C\ %#-->\ %f:%l:%c,
+			\%C%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -32,12 +32,15 @@ CompilerSet errorformat=
 
 " New errorformat (after nightly 2016/08/10)
 CompilerSet errorformat+=
+			\%-G,
+			\%-Gerror:\ aborting\ %.%#,
+			\%-Gerror:\ Could\ not\ compile\ %.%#,
 			\%Eerror:\ %m,
 			\%Eerror[E%n]:\ %m,
 			\%Wwarning:\ %m,
 			\%Inote:\ %m,
 			\%C\ %#-->\ %f:%l:%c,
-			\%C%.%#
+			\%C%*[0-9\ ]\\|%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -40,7 +40,7 @@ CompilerSet errorformat+=
 			\%Wwarning:\ %m,
 			\%Inote:\ %m,
 			\%C\ %#-->\ %f:%l:%c,
-			\%C%*[0-9\ ]\\|%.%#
+			\%C%*[0-9\ ]\|%.%#
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -20,19 +20,16 @@ function! SyntaxCheckers_rust_rustc_GetLocList() dict
     let errorformat  =
         \ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
         \ '%W%f:%l:%c: %\d%#:%\d%# %.%\{-}warning:%.%\{-} %m,' .
-        \ '%C%f:%l %m,' .
-        \ '%-Z%.%#'
+        \ '%C%f:%l %m,'
         
     " New errorformat (after nightly 2016/08/10)
     let errorformat  .=
-        \ ',' .
         \ '%Eerror: %m,' .
         \ '%Eerror[E%n]: %m,' .
         \ '%Wwarning: %m,' .
         \ '%Inote: %m,' .
         \ '%C %#--> %f:%l:%c,' .
         \ '%C%.%#'
-        
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -32,8 +32,7 @@ function! SyntaxCheckers_rust_rustc_GetLocList() dict
         \ '%Eerror[E%n]: %m,' .
         \ '%Wwarning: %m,' .
         \ '%Inote: %m,' .
-        \ '%C %#--> %f:%l:%c,' .
-        \ '%C%*[0-9 ]|%.%#'
+        \ '%C %#--> %f:%l:%c'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -16,11 +16,23 @@ set cpo&vim
 function! SyntaxCheckers_rust_rustc_GetLocList() dict
     let makeprg = self.makeprgBuild({ 'args': '-Zparse-only' })
 
+    " Old errorformat (before nightly 2016/08/10)
     let errorformat  =
         \ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
         \ '%W%f:%l:%c: %\d%#:%\d%# %.%\{-}warning:%.%\{-} %m,' .
         \ '%C%f:%l %m,' .
         \ '%-Z%.%#'
+        
+    " New errorformat (after nightly 2016/08/10)
+    let errorformat  .=
+        \ ',' .
+        \ '%Eerror: %m,' .
+        \ '%Eerror[E%n]: %m,' .
+        \ '%Wwarning: %m,' .
+        \ '%Inote: %m,' .
+        \ '%C %#--> %f:%l:%c,' .
+        \ '%C%.%#'
+        
 
     return SyntasticMake({
         \ 'makeprg': makeprg,

--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -20,16 +20,20 @@ function! SyntaxCheckers_rust_rustc_GetLocList() dict
     let errorformat  =
         \ '%E%f:%l:%c: %\d%#:%\d%# %.%\{-}error:%.%\{-} %m,'   .
         \ '%W%f:%l:%c: %\d%#:%\d%# %.%\{-}warning:%.%\{-} %m,' .
-        \ '%C%f:%l %m,'
+        \ '%C%f:%l %m'
         
     " New errorformat (after nightly 2016/08/10)
     let errorformat  .=
+        \ ',' .
+        \ '%-G,' .
+        \ '%-Gerror: aborting %.%#,' .
+        \ '%-Gerror: Could not compile %.%#,' .
         \ '%Eerror: %m,' .
         \ '%Eerror[E%n]: %m,' .
         \ '%Wwarning: %m,' .
         \ '%Inote: %m,' .
         \ '%C %#--> %f:%l:%c,' .
-        \ '%C%.%#'
+        \ '%C%*[0-9 ]|%.%#'
 
     return SyntasticMake({
         \ 'makeprg': makeprg,


### PR DESCRIPTION
This adds basic support for the new rustc error format used in recent nightlies. It appears to be working, but it's possible I've missed some edge cases, so comments are welcome.

Also, I'm not at all familiar with syntastic or how it works, so I haven't tested that part yet. If someone who uses that plugin could give this a try and let me know if it's broken, that would be great.