### PR TITLE
Fail silently on format failure

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -194,7 +194,7 @@ let b:undo_ftplugin = "
 
 " Code formatting on save
 if get(g:, "rustfmt_autosave", 0)
-	autocmd BufWritePre *.rs call rustfmt#Format()
+	autocmd BufWritePre *.rs silent! call rustfmt#Format()
 endif
 
 augroup END


### PR DESCRIPTION
Before this change when a file with syntax error was written, all its
content was printed as a formatting error message. This change makes
format command fail silently and prevents form such behaviour.
