### PR TITLE
Support format range

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -20,17 +20,20 @@ endif
 
 let s:got_fmt_error = 0
 
-function! rustfmt#Format()
-  let l:curw = winsaveview()
-  let l:tmpname = expand("%:p:h") . "/." . expand("%:p:t") . ".rustfmt"
-  call writefile(getline(1, '$'), l:tmpname)
+function! s:RustfmtCommandRange(filename, line1, line2)
+  let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
+  return printf("%s %s --write-mode=overwrite --file-lines '[%s]'", g:rustfmt_command, g:rustfmt_options, json_encode(l:arg))
+endfunction
 
-  let command = g:rustfmt_command . " --write-mode=overwrite "
+function! s:RustfmtCommand(filename)
+  return g:rustfmt_command . " --write-mode=overwrite " . g:rustfmt_options . " " . shellescape(a:filename)
+endfunction
 
+function! s:RunRustfmt(command, curw, tmpname)
   if exists("*systemlist")
-    let out = systemlist(command . g:rustfmt_options . " " . shellescape(l:tmpname))
+    let out = systemlist(a:command)
   else
-    let out = split(system(command . g:rustfmt_options . " " . shellescape(l:tmpname)), '\r\?\n')
+    let out = split(system(a:command), '\r\?\n')
   endif
 
   if v:shell_error == 0 || v:shell_error == 3
@@ -38,7 +41,7 @@ function! rustfmt#Format()
     try | silent undojoin | catch | endtry
 
     " Replace current file with temp file, then reload buffer
-    call rename(l:tmpname, expand('%'))
+    call rename(a:tmpname, expand('%'))
     silent edit!
     let &syntax = &syntax
 
@@ -76,8 +79,28 @@ function! rustfmt#Format()
     let s:got_fmt_error = 1
     lwindow
     " We didn't use the temp file, so clean up
-    call delete(l:tmpname)
+    call delete(a:tmpname)
   endif
 
-  call winrestview(l:curw)
+  call winrestview(a:curw)
+endfunction
+
+function! rustfmt#FormatRange(line1, line2)
+  let l:curw = winsaveview()
+  let l:tmpname = expand("%:p:h") . "/." . expand("%:p:t") . ".rustfmt"
+  call writefile(getline(1, '$'), l:tmpname)
+
+  let command = s:RustfmtCommandRange(l:tmpname, a:line1, a:line2)
+
+  call s:RunRustfmt(command, l:curw, l:tmpname)
+endfunction
+
+function! rustfmt#Format()
+  let l:curw = winsaveview()
+  let l:tmpname = expand("%:p:h") . "/." . expand("%:p:t") . ".rustfmt"
+  call writefile(getline(1, '$'), l:tmpname)
+
+  let command = s:RustfmtCommand(l:tmpname)
+
+  call s:RunRustfmt(command, l:curw, l:tmpname)
 endfunction

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -116,7 +116,7 @@ g:rustfmt_fail_silently~
                                                        *g:rustfmt_options*
 g:rustfmt_options~
 	Set this option to a string of options to pass to 'rustfmt'. The
-	write-mode is already set to 'overwrite'. If not specified it 
+	write-mode is already set to 'overwrite'. If not specified it
 	defaults to '' : >
 	    let g:rustfmt_options = ''
 <
@@ -218,6 +218,10 @@ COMMANDS                                                       *rust-commands*
 		will populate the |location-list| with the errors from
 		|g:rustfmt_command|. If |g:rustfmt_fail_silently| is set to 1
 		then it will not populate the |location-list|.
+
+:RustFmtRange                                                  *:RustFmtRange*
+		Runs |g:rustfmt_command| with selected range. See
+		|:RustFmt| for any other information.
 
 ==============================================================================
 MAPPINGS                                                       *rust-mappings*

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -140,6 +140,9 @@ command! -range=% RustPlay :call rust#Play(<count>, <line1>, <line2>, <f-args>)
 " See |:RustFmt| for docs
 command! -buffer RustFmt call rustfmt#Format()
 
+" See |:RustFmtRange| for docs
+command! -range -buffer RustFmtRange call rustfmt#FormatRange(<line1>, <line2>)
+
 " Mappings {{{1
 
 " Bind ⌘R in MacVim to :RustRun


### PR DESCRIPTION
`rustfmt` command supports formatting with specified ranges.
This PR adds `RustFmtRange` command using the `rustfmt --file-lines` feature.
