### PR TITLE
Don't fix paths after running cargo.

### DIFF
--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -19,14 +19,6 @@ else
     CompilerSet makeprg=cargo\ $*
 endif
 
-" Allow a configurable global Cargo.toml name. This makes it easy to
-" support variations like 'cargo.toml'.
-let s:cargo_manifest_name = get(g:, 'cargo_manifest_name', 'Cargo.toml')
-
-function! s:is_absolute(path)
-    return a:path[0] == '/' || a:path =~ '[A-Z]\+:'
-endfunction
-
 " Ignore general cargo progress messages
 CompilerSet errorformat+=
 			\%-G%\\s%#Downloading%.%#,
@@ -34,40 +26,3 @@ CompilerSet errorformat+=
 			\%-G%\\s%#Finished%.%#,
 			\%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
 			\%-G%\\s%#To\ learn\ more\\,%.%#
-
-let s:local_manifest = findfile(s:cargo_manifest_name, '.;')
-if s:local_manifest != ''
-    let s:local_manifest = fnamemodify(s:local_manifest, ':p:h').'/'
-    augroup cargo
-        au!
-        au QuickfixCmdPost make call s:FixPaths()
-    augroup END
-
-    " FixPaths() is run after Cargo, and is used to change the file paths
-    " to be relative to the current directory instead of Cargo.toml.
-    function! s:FixPaths()
-        let qflist = getqflist()
-        let manifest = s:local_manifest
-        for qf in qflist
-            if !qf.valid
-                let m = matchlist(qf.text, '(file://\(.*\))$')
-                if !empty(m)
-                    let manifest = m[1].'/'
-                    " Manually strip another slash if needed; usually just an
-                    " issue on Windows.
-                    if manifest =~ '^/[A-Z]\+:/'
-                        let manifest = manifest[1:]
-                    endif
-                endif
-                continue
-            endif
-            let filename = bufname(qf.bufnr)
-            if s:is_absolute(filename)
-                continue
-            endif
-            let qf.filename = simplify(manifest.filename)
-            call remove(qf, 'bufnr')
-        endfor
-        call setqflist(qflist, 'r')
-    endfunction
-endif

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -88,13 +88,6 @@ g:ftplugin_rust_source_path~
 	    let g:ftplugin_rust_source_path = $HOME.'/dev/rust'
 <
 
-                                                      *g:cargo_manifest_name*
-g:cargo_manifest_name~
-	Set this option to the name of the manifest file for your projects. If
-	not specified it defaults to 'Cargo.toml' : >
-	        let g:cargo_manifest_name = 'Cargo.toml'
-<
-
                                                        *g:rustfmt_command*
 g:rustfmt_command~
 	Set this option to the name of the 'rustfmt' executable in your $PATH. If


### PR DESCRIPTION
Recently, vim started reporting Rust compilation errors in non-existent filenames in my multi-crate repository. Possibly after I installed rustc 1.12. The problem is caused by the FixPaths function in compiler/cargo.vim which would rewrite `Cargo.toml`-relative paths to current directory-relative paths. However, it would use the wrong `Cargo.toml`.

Cargo now emits paths that are relative to the current directory, not `Cargo.toml`, so the path rewriting is no longer necessary.

Also remove the documentation for the `g:cargo_manifest_name` setting which isn't used any more.
