### PR TITLE
Prevent N+ instances of rustfmt#Format() to occur on write

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -110,16 +110,6 @@ xnoremap <silent> <buffer> ]] :call rust#Jump('v', 'Forward')<CR>
 onoremap <silent> <buffer> [[ :call rust#Jump('o', 'Back')<CR>
 onoremap <silent> <buffer> ]] :call rust#Jump('o', 'Forward')<CR>
 
-" %-matching. <:> is handy for generics.
-set matchpairs+=<:>
-" There are two minor issues with it; (a) comparison operators in expressions,
-" where a less-than may match a greater-than later on—this is deemed a trivial
-" issue—and (b) `Fn() -> X` syntax. This latter issue is irremediable from the
-" highlighting perspective (built into Vim), but the actual % functionality
-" can be fixed by this use of matchit.vim.
-let b:match_skip = 's:comment\|string\|rustArrow'
-source $VIMRUNTIME/macros/matchit.vim
-
 " Commands {{{1
 
 " See |:RustRun| for docs
@@ -198,6 +188,16 @@ if get(g:, "rustfmt_autosave", 0)
 endif
 
 augroup END
+
+" %-matching. <:> is handy for generics.
+set matchpairs+=<:>
+" There are two minor issues with it; (a) comparison operators in expressions,
+" where a less-than may match a greater-than later on—this is deemed a trivial
+" issue—and (b) `Fn() -> X` syntax. This latter issue is irremediable from the
+" highlighting perspective (built into Vim), but the actual % functionality
+" can be fixed by this use of matchit.vim.
+let b:match_skip = 's:comment\|string\|rustArrow'
+source $VIMRUNTIME/macros/matchit.vim
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -177,6 +177,7 @@ let b:undo_ftplugin = "
 		\|ounmap <buffer> ]]
 		\|set matchpairs-=<:>
 		\|unlet b:match_skip
+		\|autocmd! rust.vim
 		\|augroup! rust.vim
 		\"
 


### PR DESCRIPTION
I'm not 100% sure what it is about the act of sourcing `matchit.vim` but something about it being midway through the `augroup` declaration was causing `aucmds` to not correctly register to the group. This was in turn causing them to not get deleted and when the plugin was rerun.

By moving the `matchit.vim` support towards the end of the file, after the `augroup END` we no longer end up with N+ instances of `aucmd BufPreWrite *.rs rustfmt#Format()` set.

This change had a side effect of causing a warning/error to raise in the `b:undo_ftplugin`. While the plugin is deleting the `augroup` the group isn't empty. So I've added a line of code to first purge the `augroup` to prevent the warning.

Fixes #115