### PR TITLE
compiler/cargo.vim: remove FixPaths() function

### DIFF
--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -23,10 +23,6 @@ endif
 " support variations like 'cargo.toml'.
 let s:cargo_manifest_name = get(g:, 'cargo_manifest_name', 'Cargo.toml')
 
-function! s:is_absolute(path)
-    return a:path[0] == '/' || a:path =~ '[A-Z]\+:'
-endfunction
-
 " Ignore general cargo progress messages
 CompilerSet errorformat+=
 			\%-G%\\s%#Downloading%.%#,
@@ -34,40 +30,3 @@ CompilerSet errorformat+=
 			\%-G%\\s%#Finished%.%#,
 			\%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
 			\%-G%\\s%#To\ learn\ more\\,%.%#
-
-let s:local_manifest = findfile(s:cargo_manifest_name, '.;')
-if s:local_manifest != ''
-    let s:local_manifest = fnamemodify(s:local_manifest, ':p:h').'/'
-    augroup cargo
-        au!
-        au QuickfixCmdPost make call s:FixPaths()
-    augroup END
-
-    " FixPaths() is run after Cargo, and is used to change the file paths
-    " to be relative to the current directory instead of Cargo.toml.
-    function! s:FixPaths()
-        let qflist = getqflist()
-        let manifest = s:local_manifest
-        for qf in qflist
-            if !qf.valid
-                let m = matchlist(qf.text, '(file://\(.*\))$')
-                if !empty(m)
-                    let manifest = m[1].'/'
-                    " Manually strip another slash if needed; usually just an
-                    " issue on Windows.
-                    if manifest =~ '^/[A-Z]\+:/'
-                        let manifest = manifest[1:]
-                    endif
-                endif
-                continue
-            endif
-            let filename = bufname(qf.bufnr)
-            if s:is_absolute(filename)
-                continue
-            endif
-            let qf.filename = simplify(manifest.filename)
-            call remove(qf, 'bufnr')
-        endfor
-        call setqflist(qflist, 'r')
-    endfunction
-endif


### PR DESCRIPTION
With cargo from rust 1.12.1 (but behaviour might have changed in earlier
versions), cargo is calling rustc with path related to the current
directory. There is no longer need to call FixPaths()
I had issue with FixPath because I'm calling cargo build from the src/
directory but FixPath would show errors on paths that do no contain src/.