### PR TITLE
Remove all augroup references from b:undo_ftplugin

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -177,8 +177,6 @@ let b:undo_ftplugin = "
 		\|ounmap <buffer> ]]
 		\|set matchpairs-=<:>
 		\|unlet b:match_skip
-		\|autocmd! rust.vim
-		\|augroup! rust.vim
 		\"
 
 " }}}1


### PR DESCRIPTION
This was causing additional issues on some setups of vim as show in
[issue#120](https://github.com/rust-lang/rust.vim/issues/120). I thought about several ways to resolve this and my albeit
limited knowledge of vimscript couldn't come up with one. Ultimately I
resolved that it shouldn't be an issue since the augroup already clears
itself every time the augroup loads itself. In addition the aucommands
are already limited in scope to `*.rs` buffers. So they should be safe.

From my testing the core issue seems to be that `autocmd!` (on some
versions of vim?) doesn't stop parsing the name of the augroup at the
end of the line so instead of it trying to clear `autocmd! rust.vim` it
instead attempts to clear `autocmd! rust.vim|augroup!rust.vim` which
obviously isn't the name of the `augroup`.