### PR TITLE
Avoid warning of -Z due to #31793

### DIFF
--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -30,6 +30,7 @@ function! SyntaxCheckers_rust_rustc_GetLocList() dict
         \ '%-Gerror: Could not compile %.%#,' .
         \ '%Eerror: %m,' .
         \ '%Eerror[E%n]: %m,' .
+        \ '%-Gwarning: the option `Z` is unstable %.%#,' .
         \ '%Wwarning: %m,' .
         \ '%Inote: %m,' .
         \ '%C %#--> %f:%l:%c'


### PR DESCRIPTION
from rust-lang/rust#31793 the usage of -Z on the stable channel will now emit a warning, which should be avoided in syntax checking.