### PR TITLE
Do not call rustc with -Z arguments in syntastic plugin

### DIFF
--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -14,7 +14,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_rust_rustc_GetLocList() dict
-    let makeprg = self.makeprgBuild({ 'args': '-Zparse-only' })
+    let makeprg = self.makeprgBuild({})
 
     " Old errorformat (before nightly 2016/08/10)
     let errorformat  =


### PR DESCRIPTION
The flag is unstable, and is now generating a warning - which makes
the syntastic plugin unusable. Without it, we probably have a longer
analysis time, but it at least works. Issue rust-lang/rust#31847
explains the rustc side.

This fixes rust-lang/rust.vim#113.