### PR TITLE
Add a cargo checker for syntastic

### DIFF
--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -8,15 +8,18 @@
 if exists("g:loaded_syntastic_rust_cargo_checker")
     finish
 endif
+
 let g:loaded_syntastic_rust_cargo_checker = 1
 
+" Force syntastic to call cargo without a specific file name
 let g:syntastic_rust_cargo_fname = ""
 
 let s:save_cpo = &cpo
 set cpo&vim
 
 function! SyntaxCheckers_rust_cargo_IsAvailable() dict
-  return executable(self.getExec())
+  return executable(self.getExec()) &&
+    \ syntastic#util#versionIsAtLeast(self.getVersion(), [0, 16, 0])
 endfunction
 
 function! SyntaxCheckers_rust_cargo_GetLocList() dict
@@ -26,8 +29,7 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
     let errorformat  =
         \ '%-G,' .
         \ '%-Gerror: aborting %.%#,' .
-        \ '%-Gerror: Could not compile %.%#,' .
-        \ '%-Gwarning: the option `Z` is unstable %.%#,'
+        \ '%-Gerror: Could not compile %.%#,'
 
     " Meaningful lines (errors, notes, warnings, contextual information)
     let errorformat .=

--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -1,0 +1,50 @@
+" Vim syntastic plugin
+" Language:     Rust
+" Maintainer:   Julien Levesy <jlevesy@gmail.com>
+"
+" See for details on how to add an external Syntastic checker:
+" https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide#external
+
+if exists("g:loaded_syntastic_rust_cargo_checker")
+    finish
+endif
+let g:loaded_syntastic_rust_cargo_checker = 1
+
+let g:syntastic_rust_cargo_fname = ""
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_rust_cargo_IsAvailable() dict
+  return executable(self.getExec())
+endfunction
+
+function! SyntaxCheckers_rust_cargo_GetLocList() dict
+    let makeprg = self.makeprgBuild({ "args": "check" })
+
+    " Ignored patterns, and blank lines
+    let errorformat  =
+        \ '%-G,' .
+        \ '%-Gerror: aborting %.%#,' .
+        \ '%-Gerror: Could not compile %.%#,' .
+        \ '%-Gwarning: the option `Z` is unstable %.%#,'
+
+    " Meaningful lines (errors, notes, warnings, contextual information)
+    let errorformat .=
+        \ '%Eerror: %m,' .
+        \ '%Eerror[E%n]: %m,' .
+        \ '%Wwarning: %m,' .
+        \ '%Inote: %m,' .
+        \ '%C %#--> %f:%l:%c'
+
+    return SyntasticMake({
+        \ 'makeprg': makeprg,
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+    \ 'filetype': 'rust',
+    \ 'name': 'cargo'})
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -41,6 +41,7 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
+        \ 'cwd': expand('%:p:h'),
         \ 'errorformat': errorformat })
 endfunction
 


### PR DESCRIPTION
Hi there !

As cargo check has been merged in cargo (see https://github.com/rust-lang/cargo/pull/3296),  and the current rustc checker is facing some issues with external crates (see https://github.com/rust-lang/rust.vim/issues/130), I gave a try implementing a cargo checker for syntastic.

And here is the result. Please note it is my first time writing a syntastic checker, and I'm relatively new to the rust ecosystem, consequently I might have made mistakes, so any feedback will be greatly appreciated !

It currently works with cargo 0.16.0 nightly.

Thanks !