### PR TITLE
Change `unsafe` highlighting to `Exception`

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -32,7 +32,8 @@ syn keyword   rustKeyword     in impl let
 syn keyword   rustKeyword     pub nextgroup=rustPubScope skipwhite skipempty
 syn keyword   rustKeyword     return
 syn keyword   rustSuper       super
-syn keyword   rustKeyword     unsafe where
+syn keyword   rustKeyword     where
+syn keyword   rustUnsafeKeyword unsafe
 syn keyword   rustKeyword     use nextgroup=rustModPath skipwhite skipempty
 " FIXME: Scoped impl's name is also fallen in this category
 syn keyword   rustKeyword     mod trait nextgroup=rustIdentifier skipwhite skipempty
@@ -246,6 +247,7 @@ hi def link rustUnion         rustStructure
 hi def link rustPubScopeDelim Delimiter
 hi def link rustPubScopeCrate rustKeyword
 hi def link rustSuper         rustKeyword
+hi def link rustUnsafeKeyword Exception
 hi def link rustReservedKeyword Error
 hi def link rustRepeat        Conditional
 hi def link rustConditional   Conditional


### PR DESCRIPTION
It has a new group now, `rustUnsafeKeyword`, which allows the user to easily customise the highlighting if they desire. (Example: if you wanted to visually forbid `unsafe`, you could highlight it as `Error` by putting `hi link rustUnsafeKeyword Error` in your `.vimrc` or `.vim/after/syntax/rust.vim`.)

I also made this group link to `Exception` rather than `Keyword`. This is potentially mildly controversial. It’s common for `Exception` and `Keyword` to be highlighted the same, so many users won’t see this change. Still, it *is* a change, and one people may not like. We could back that part of it out easily enough. (This is also the reason I made this a PR rather than just pushing it directly to rust-lang/rust.vim.)

Closes #144.

/cc @bluss