### PR TITLE
Quickfix mode: Support assertion failure messages

### DIFF
--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -25,4 +25,6 @@ CompilerSet errorformat+=
 			\%-G%\\s%#Compiling%.%#,
 			\%-G%\\s%#Finished%.%#,
 			\%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
-			\%-G%\\s%#To\ learn\ more\\,%.%#
+			\%-G%\\s%#To\ learn\ more\\,%.%#,
+			\%-Gnote:\ Run\ with\ \`RUST_BACKTRACE=%.%#,
+			\%.%#panicked\ at\ \\'%m\\'\\,\ %f:%l


### PR DESCRIPTION
Such that you can quickly navigate between assertion failure
locations when you run `cargo test` (i.e. via `:make test`).

The user experience is then analogous to what you get with GCC
and common unittesting C++/C libraries like Catch/Boost/libcheck
when calling `:make check` or `:make test` from Vim.