### PR TITLE
Add g:rust_clip_command to allow to copy the playpen url to the clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ options.
 The `:RustPlay` command will send the current selection, or if
 nothing is selected the current buffer, to the [Rust playpen][pp].
 
+If you set g:rust_clip_command RustPlay will copy the url to the clipboard.
+
+- Mac:
+
+        let g:rust_clip_command = 'pbcopy'
+
+- Linux:
+
+        let g:rust_clip_command = 'xclip -selection clipboard'
+
 [rfmt]: https://crates.io/crates/rustfmt/
 
 ## Help

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -407,6 +407,10 @@ function! rust#Play(count, line1, line2, ...) abort
     let res = webapi#http#post(l:rust_shortener_url.'create.php', payload, {})
     let url = res.content
 
+    if exists('g:rust_clip_command')
+	call system(g:rust_clip_command, url)
+    endif
+
     redraw | echomsg 'Done: '.url
 endfunction
 

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -126,6 +126,12 @@ g:rust_shortener_url~
 	    let g:rust_shortener_url = 'https://is.gd/'
 <
 
+                                                        *g:rust_clip_command*
+g:rust_clip_command~
+	Set this option to the command used in your OS to copy the Rust Play
+	url to the clipboard: >
+	    let g:rust_clip_command = 'xclip -selection clipboard'
+<
 
 ==============================================================================
 COMMANDS                                                       *rust-commands*
@@ -201,6 +207,9 @@ COMMANDS                                                       *rust-commands*
 
 		|g:rust_shortener_url| is the base url for the shorterner, by
 		default "https://is.gd/"
+
+		|g:rust_clip_command| is the command to run to copy the
+		playpen url to the clipboard of your system.
 
 :RustFmt                                                       *:RustFmt*
 		Runs |g:rustfmt_command| on the current buffer. If


### PR DESCRIPTION
The idea is to add g:rust_clip_command in the same way https://github.com/mattn/gist-vim.git does here https://github.com/mattn/gist-vim/blob/dd345b/autoload/gist.vim#L946 to be able to just run :RustPlay and get the url copied to the clipboard.