### PR TITLE
Execute the rustfmt prewrite hook at all times.

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -184,10 +184,14 @@ let b:undo_ftplugin = "
 
 " }}}1
 
+function! RustWritePreHook()
+	if get(g:, "rustfmt_autosave", 0)
+		 silent! call rustfmt#Format()
+	endif
+endfunction
+
 " Code formatting on save
-if get(g:, "rustfmt_autosave", 0)
-	autocmd BufWritePre *.rs silent! call rustfmt#Format()
-endif
+autocmd BufWritePre *.rs call RustWritePreHook()
 
 augroup END
 


### PR DESCRIPTION
Currently `rustfmt` won't be run if the `g:rustfmt_autosave` setting was
enabled during the runtime, after the plugin and `rs` file were already
loaded.

This patch executes the hook unconditionally and makes the actual
decision to run `rustfmt` on every save.