### PR TITLE
Check tests, examples, and benchmarks with cargo

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -101,6 +101,22 @@ if has('conceal') && exists('g:rust_conceal') && g:rust_conceal != 0
 	setlocal conceallevel=2
 endif
 
+" When checking with syntastic, pass --tests, --examples, etc. to cargo based
+" on the file location
+if exists('g:loaded_syntastic_plugin')
+	let cargodir = fnamemodify(findfile('Cargo.toml', '.;'), ':p:h')
+	if !empty(cargodir)
+		let abspath = fnamemodify(expand('%'), ':p')
+		if abspath =~ '^' . cargodir . '/tests'
+			let b:syntastic_rust_cargo_args = 'check --tests'
+		elseif abspath =~ '^' . cargodir . '/examples'
+			let b:syntastic_rust_cargo_args = 'check --examples'
+		elseif abspath =~ '^' . cargodir . '/benches'
+			let b:syntastic_rust_cargo_args = 'check --benches'
+		endif
+	endif
+endif
+
 " Motion Commands {{{1
 
 " Bind motion commands to support hanging indents

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -107,11 +107,19 @@ if exists('g:loaded_syntastic_plugin')
 	let cargodir = fnamemodify(findfile('Cargo.toml', '.;'), ':p:h')
 	if !empty(cargodir)
 		let abspath = fnamemodify(expand('%'), ':p')
-		if abspath =~ '^' . cargodir . '/tests'
+
+		" Attempt to determine the path separator
+		if abspath[0] == '/'
+			let path_sep = '/'
+		else
+			let path_sep = '\'
+		endif
+
+		if abspath =~ '\V\^' . escape(cargodir . path_sep . 'tests' . path_sep, '\')
 			let b:syntastic_rust_cargo_args = 'check --tests'
-		elseif abspath =~ '^' . cargodir . '/examples'
+		elseif abspath =~ '\V\^' . escape(cargodir . path_sep . 'examples' . path_sep, '\')
 			let b:syntastic_rust_cargo_args = 'check --examples'
-		elseif abspath =~ '^' . cargodir . '/benches'
+		elseif abspath =~ '\V\^' . escape(cargodir . path_sep . 'benches' . path_sep, '\')
 			let b:syntastic_rust_cargo_args = 'check --benches'
 		endif
 	endif


### PR DESCRIPTION
With no extra arguments, `cargo check` does not check any files under `tests`, `examples`, or `benches`, so the Cargo Syntastic checker cannot be used. Passing `--tests`, etc. to Cargo addresses this problem.

The slowness of running `cargo check` is slightly mitigated by omitting the flags unless the file is under one of said directories (as opposed to just doing `cargo check --tests --examples --benches` every time).  The checker is still not perfect, as `cargo check` never scans unit tests and Syntastic unpredictably fails when multiple buffers are open.