### PR TITLE
Add check to skip unsetting style in ftplugin

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -40,6 +40,7 @@ silent! setlocal formatoptions+=j
 setlocal smartindent nocindent
 
 if !exists("g:rust_recommended_style") || g:rust_recommended_style != 0
+	let b:rust_set_style = 1
 	setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab
 	setlocal textwidth=99
 endif
@@ -150,7 +151,9 @@ endif
 
 let b:undo_ftplugin = "
 		\ setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd<
-		\|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
+		\|if exists('b:rust_set_style')
+		  \|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
+		\|endif
 		\|if exists('b:rust_original_delimitMate_excluded_regions')
 		  \|let b:delimitMate_excluded_regions = b:rust_original_delimitMate_excluded_regions
 		  \|unlet b:rust_original_delimitMate_excluded_regions


### PR DESCRIPTION
When this command is present in `b:undo_ftplugin`, it undoes the automatic configuration done by editorconfig-vim. I have no idea why this is; my only hypothesis is that, after `.editorconfig` is loaded, this ftplugin is loaded, unloaded, and then loaded again, which would have this effect.

Ideally, the real problem would be fixed in the offending plugin, but this band-aid solution happens to fix it in my case and is innocuous enough not to cause issues for other users.