### PR TITLE
Makes the cargo be default compiler

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -199,4 +199,6 @@ let b:match_skip = 's:comment\|string\|rustArrow'
 let &cpo = s:save_cpo
 unlet s:save_cpo
 
+compiler cargo
+
 " vim: set noet sw=8 ts=8:


### PR DESCRIPTION
It is quite annoying to set compiler to be `cargo` manually on every vim restart.

Since `cargo` is a part of the `rust` infrastructure I believe that it is legitimate to have it as a default compiler.