### PR TITLE
Preserve file permissions on rustfmt

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -89,7 +89,9 @@ endfunction
 function! rustfmt#FormatRange(line1, line2)
 	let l:curw = winsaveview()
 	let l:tmpname = expand("%:p:h") . "/." . expand("%:p:t") . ".rustfmt"
+	let l:permissions = getfperm(@%)
 	call writefile(getline(1, '$'), l:tmpname)
+	call setfperm(l:tmpname, l:permissions)
 
 	let command = s:RustfmtCommandRange(l:tmpname, a:line1, a:line2)
 
@@ -99,7 +101,9 @@ endfunction
 function! rustfmt#Format()
 	let l:curw = winsaveview()
 	let l:tmpname = expand("%:p:h") . "/." . expand("%:p:t") . ".rustfmt"
+	let l:permissions = getfperm(@%)
 	call writefile(getline(1, '$'), l:tmpname)
+	call setfperm(l:tmpname, l:permissions)
 
 	let command = s:RustfmtCommand(l:tmpname)
 


### PR DESCRIPTION
Currently running `RustFmt` is resetting the file permissions.

`RustFmt` does the following steps:

1. create a temporary file
2. copy the contents of the current buffer to the temporary file
3. run `rustfmt` on the temporary file
4. replace the current file with the temporary one

The problem is in the first step since it is performing a simple `writefile`, it inherits the default file permissions for the directory.

After this pull request, the file permissions are copied from the source file to the temporary file after step 2:

1. create a temporary file
2. copy the contents of the current buffer to the temporary file
3. copy file permissions
4. run `rustfmt` on the temporary file
5. replace the current file with the temporary one