### PR TITLE
Cleanup cargo commands

### DIFF
--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -8,7 +8,6 @@ function! cargo#build(args)
     else
         execute "! cargo build"
     endif
-    execute "! cargo build"
 endfunction
 
 function! cargo#clean(args)
@@ -17,7 +16,6 @@ function! cargo#clean(args)
     else
         execute "! cargo clean"
     endif
-    execute "! cargo clean"
 endfunction
 
 function! cargo#doc(args)

--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -1,30 +1,30 @@
 function! cargo#cmd(args)
-    execute "!" . "cargo ". a:args
+    execute "! cargo ". a:args
 endfunction
 
 function! cargo#build(args)
     if !a:args
-        execute "!" . "cargo build " . a:args
+        execute "! cargo build " . a:args
     else
-        execute "!" . "cargo build"
+        execute "! cargo build"
     endif
-    execute "!" . "cargo build"
+    execute "! cargo build"
 endfunction
 
 function! cargo#clean(args)
     if !a:args
-        execute "!" . "cargo clean " . a:args
+        execute "! cargo clean " . a:args
     else
-        execute "!" . "cargo clean"
+        execute "! cargo clean"
     endif
-    execute "!" . "cargo clean"
+    execute "! cargo clean"
 endfunction
 
 function! cargo#doc(args)
     if !a:args
-        execute "!" . "cargo doc " . a:args
+        execute "! cargo doc " . a:args
     else
-        execute "!" . "cargo doc"
+        execute "! cargo doc"
     endif
 endfunction
 
@@ -35,32 +35,32 @@ endfunction
 
 function! cargo#init(args)
     if !a:args
-        execute "!" . "cargo init " . a:args
+        execute "! cargo init " . a:args
     else
-        execute "!" . "cargo init"
+        execute "! cargo init"
     endif
 endfunction
 
 function! cargo#run(args)
     if !a:args
-        execute "!" . "cargo run " . a:args
+        execute "! cargo run " . a:args
     else
-        execute "!" . "cargo run"
+        execute "! cargo run"
     endif
 endfunction
 
 function! cargo#test(args)
     if !a:args
-        execute "!" . "cargo test " . a:args
+        execute "! cargo test " . a:args
     else
-        execute "!" . "cargo test"
+        execute "! cargo test"
     endif
 endfunction
 
 function! cargo#bench(args)
     if !a:args
-        execute "!" . "cargo bench " . a:args
+        execute "! cargo bench " . a:args
     else
-        execute "!" . "cargo bench"
+        execute "! cargo bench"
     endif
 endfunction

--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -1,64 +1,36 @@
 function! cargo#cmd(args)
-    execute "! cargo ". a:args
+    execute "! cargo" a:args
 endfunction
 
 function! cargo#build(args)
-    if !a:args
-        execute "! cargo build " . a:args
-    else
-        execute "! cargo build"
-    endif
+    call cargo#cmd("build " . a:args)
 endfunction
 
 function! cargo#clean(args)
-    if !a:args
-        execute "! cargo clean " . a:args
-    else
-        execute "! cargo clean"
-    endif
+    call cargo#cmd("clean " . a:args)
 endfunction
 
 function! cargo#doc(args)
-    if !a:args
-        execute "! cargo doc " . a:args
-    else
-        execute "! cargo doc"
-    endif
+    call cargo#cmd("doc " . a:args)
 endfunction
 
 function! cargo#new(args)
-    execute "!cargo new " . a:args
+    call cargo#cmd("new " . a:args)
     cd `=a:args`
 endfunction
 
 function! cargo#init(args)
-    if !a:args
-        execute "! cargo init " . a:args
-    else
-        execute "! cargo init"
-    endif
+    call cargo#cmd("init " . a:args)
 endfunction
 
 function! cargo#run(args)
-    if !a:args
-        execute "! cargo run " . a:args
-    else
-        execute "! cargo run"
-    endif
+    call cargo#cmd("run " . a:args)
 endfunction
 
 function! cargo#test(args)
-    if !a:args
-        execute "! cargo test " . a:args
-    else
-        execute "! cargo test"
-    endif
+    call cargo#cmd("test " . a:args)
 endfunction
 
 function! cargo#bench(args)
-    if !a:args
-        execute "! cargo bench " . a:args
-    else
-        execute "! cargo bench"
-    endif
+    call cargo#cmd("bench " . a:args)
 endfunction

--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -1,9 +1,5 @@
 function! cargo#cmd(args)
-    if !a:args
-        execute "!" . "cargo ". a:args
-    else
-        echom "Missing arguments"
-    endif
+    execute "!" . "cargo ". a:args
 endfunction
 
 function! cargo#build(args)
@@ -33,12 +29,8 @@ function! cargo#doc(args)
 endfunction
 
 function! cargo#new(args)
-    if !a:args
-        execute "!cargo new " . a:args
-        :cd `=a:args`
-    else
-        echom "Missing arguments"
-    endif
+    execute "!cargo new " . a:args
+    cd `=a:args`
 endfunction
 
 function! cargo#init(args)

--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -1,5 +1,4 @@
 function! cargo#cmd(args)
-    silent! clear
     if !a:args
         execute "!" . "cargo ". a:args
     else
@@ -8,29 +7,24 @@ function! cargo#cmd(args)
 endfunction
 
 function! cargo#build(args)
-    silent! clear
     if !a:args
         execute "!" . "cargo build " . a:args
     else
         execute "!" . "cargo build"
     endif
-    silent! clear
     execute "!" . "cargo build"
 endfunction
 
 function! cargo#clean(args)
-    silent! clear
     if !a:args
         execute "!" . "cargo clean " . a:args
     else
         execute "!" . "cargo clean"
     endif
-    silent! clear
     execute "!" . "cargo clean"
 endfunction
 
 function! cargo#doc(args)
-    silent! clear
     if !a:args
         execute "!" . "cargo doc " . a:args
     else
@@ -39,7 +33,6 @@ function! cargo#doc(args)
 endfunction
 
 function! cargo#new(args)
-    silent! clear
     if !a:args
         execute "!cargo new " . a:args
         :cd `=a:args`
@@ -49,7 +42,6 @@ function! cargo#new(args)
 endfunction
 
 function! cargo#init(args)
-    silent! clear
     if !a:args
         execute "!" . "cargo init " . a:args
     else
@@ -58,7 +50,6 @@ function! cargo#init(args)
 endfunction
 
 function! cargo#run(args)
-    silent! clear
     if !a:args
         execute "!" . "cargo run " . a:args
     else
@@ -67,7 +58,6 @@ function! cargo#run(args)
 endfunction
 
 function! cargo#test(args)
-    silent! clear
     if !a:args
         execute "!" . "cargo test " . a:args
     else
@@ -76,7 +66,6 @@ function! cargo#test(args)
 endfunction
 
 function! cargo#bench(args)
-    silent! clear
     if !a:args
         execute "!" . "cargo bench " . a:args
     else

--- a/plugin/rust.vim
+++ b/plugin/rust.vim
@@ -21,11 +21,11 @@ endif
 let &cpo = s:save_cpo
 unlet s:save_cpo
 
-command! -nargs=* Cargo call cargo#cmd(<q-args>)
+command! -nargs=+ Cargo call cargo#cmd(<q-args>)
 command! -nargs=* Cbuild call cargo#build(<q-args>)
 command! -nargs=* Cclean call cargo#clean(<q-args>)
 command! -nargs=* Cdoc call cargo#doc(<q-args>)
-command! -nargs=* Cnew call cargo#new(<q-args>)
+command! -nargs=+ Cnew call cargo#new(<q-args>)
 command! -nargs=* Cinit call cargo#init(<q-args>)
 command! -nargs=* Crun call cargo#run(<q-args>)
 command! -nargs=* Ctest call cargo#test(<q-args>)

--- a/plugin/rust.vim
+++ b/plugin/rust.vim
@@ -2,10 +2,10 @@
 " Language:     Rust
 " Maintainer:   Andrew Gallant <jamslam@gmail.com>
 
-if exists("g:loaded_syntastic_rust_filetype")
-  finish
+if exists("g:loaded_rust_vim")
+    finish
 endif
-let g:loaded_syntastic_rust_filetype = 1
+let g:loaded_rust_vim = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -17,9 +17,6 @@ if exists('g:syntastic_extra_filetypes')
 else
     let g:syntastic_extra_filetypes = ['rust']
 endif
-
-let &cpo = s:save_cpo
-unlet s:save_cpo
 
 command! -nargs=+ Cargo call cargo#cmd(<q-args>)
 command! -nargs=* Cbuild call cargo#build(<q-args>)
@@ -34,3 +31,6 @@ command! -nargs=* Cupdate call cargo#update(<q-args>)
 command! -nargs=* Csearch  call cargo#search(<q-args>)
 command! -nargs=* Cpublish call cargo#publish(<q-args>)
 command! -nargs=* Cinstall call cargo#install(<q-args>)
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
I found some mistakes and redundancy in implementation of cargo commands. I fixed them as following:

- `:clear` is abbreviation of `:clearjump` and it is not necessary for running command
- `-nargs=+` checks the command should have one or more args. So it should not be checked in a function
- `"." . "foo"` is the same as `". foo"`.
- Some commands are wrongly run twice
- Remove boring boilerplates by reusing `cargo#cmd()`
- Fix the guard variable name. `plugin/rust.vim` is not only for syntastic
- Fix position of cpo-save in `plugin/rust.vim`. It must be restored at the end of the file