### PR TITLE
Add filename to the end of RustFmtRange command

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -23,7 +23,7 @@ let s:got_fmt_error = 0
 
 function! s:RustfmtCommandRange(filename, line1, line2)
 	let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
-	return printf("%s %s --write-mode=overwrite --file-lines '[%s]'", g:rustfmt_command, g:rustfmt_options, json_encode(l:arg))
+	return printf("%s %s --write-mode=overwrite --file-lines '[%s]' %s", g:rustfmt_command, g:rustfmt_options, json_encode(l:arg), shellescape(a:filename))
 endfunction
 
 function! s:RustfmtCommand(filename)


### PR DESCRIPTION
Addresses #156 

The `--file-lines` argument seems to need the filename at the end of the command. 

With this change the :RustFmtRange command now works on all selections where executing the `rustfmt` command in the terminal would work. 

For the following code executing
```bash
rustfmt --write-mode=overwrite --file-lines '[{"file": "example.rs", "range": [0, 2]}]' example.rs
```
and highlighting the first two lines and run `:RustFmtRange` does the same:
```rust
struct A {
t: i64,
}

mod foo {
    fn bar() {
                         // test
                             let i = 12;
                                 // test
    }
    // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
    fn baz() {
        let j = 15;
    }
}

```

The `:RustFmtRange` command is still limited by https://github.com/rust-lang-nursery/rustfmt/issues/1514