### PR TITLE
set cwd path to project's root (containing Cargo.toml)

### DIFF
--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -41,7 +41,7 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
-        \ 'cwd': expand('%:p:h'),
+        \ 'cwd': fnamemodify(findfile("Cargo.toml", ".;"), ":p:h"),
         \ 'errorformat': errorformat })
 endfunction
 

--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -41,7 +41,7 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
 
     return SyntasticMake({
         \ 'makeprg': makeprg,
-        \ 'cwd': fnamemodify(findfile("Cargo.toml", ".;"), ":p:h"),
+        \ 'cwd': fnamemodify(findfile("Cargo.lock", ".;"), ":p:h"),
         \ 'errorformat': errorformat })
 endfunction
 


### PR DESCRIPTION
This fixes issue #196 

Checked with:
```
rustc 1.25.0 (84203cac6 2018-03-25)
cargo 0.26.0 (41480f5cc 2018-02-26)
```
and syntastic master (vim-syntastic/syntastic@e3a819c7)