### PR TITLE
Query g: with get() instead of using exists() and checking the value

### DIFF
--- a/after/syntax/rust.vim
+++ b/after/syntax/rust.vim
@@ -1,9 +1,9 @@
-if !exists('g:rust_conceal') || g:rust_conceal == 0 || !has('conceal') || &enc != 'utf-8'
+if !get(g:, 'rust_conceal', 0) || !has('conceal') || &enc != 'utf-8'
 	finish
 endif
 
 " For those who don't want to see `::`...
-if exists('g:rust_conceal_mod_path') && g:rust_conceal_mod_path != 0
+if get(g:, 'rust_conceal_mod_path', 0)
 	syn match rustNiceOperator "::" conceal cchar=ㆍ
 endif
 
@@ -18,7 +18,7 @@ syn match rustNiceOperator "=>" contains=rustFatRightArrowHead,rustFatRightArrow
 syn match rustNiceOperator /\<\@!_\(_*\>\)\@=/ conceal cchar=′
 
 " For those who don't want to see `pub`...
-if exists('g:rust_conceal_pub') && g:rust_conceal_pub != 0
+if get(g:, 'rust_conceal_pub', 0)
     syn match rustPublicSigil contained "pu" conceal cchar=＊
     syn match rustPublicRest contained "b" conceal cchar= 
     syn match rustNiceOperator "pub " contains=rustPublicSigil,rustPublicRest
@@ -26,7 +26,7 @@ endif
 
 hi link rustNiceOperator Operator
 
-if !(exists('g:rust_conceal_mod_path') && g:rust_conceal_mod_path != 0)
+if !get(g:, 'rust_conceal_mod_path', 0)
     hi! link Conceal Operator
 
     " And keep it after a colorscheme change

--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -16,7 +16,7 @@ if exists(":CompilerSet") != 2
 	command -nargs=* CompilerSet setlocal <args>
 endif
 
-if exists("g:rustc_makeprg_no_percent") && g:rustc_makeprg_no_percent != 0
+if get(g:, 'rustc_makeprg_no_percent', 0)
 	CompilerSet makeprg=rustc
 else
 	CompilerSet makeprg=rustc\ \%

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -22,7 +22,7 @@ autocmd!
 " comments, so we'll use that as our default, but make it easy to switch.
 " This does not affect indentation at all (I tested it with and without
 " leader), merely whether a leader is inserted by default or not.
-if exists("g:rust_bang_comment_leader") && g:rust_bang_comment_leader != 0
+if get(g:, 'rust_bang_comment_leader', 0)
 	" Why is the `,s0:/*,mb:\ ,ex:*/` there, you ask? I don't understand why,
 	" but without it, */ gets indented one space even if there were no
 	" leaders. I'm fairly sure that's a Vim bug.
@@ -39,7 +39,7 @@ silent! setlocal formatoptions+=j
 " otherwise it's better than nothing.
 setlocal smartindent nocindent
 
-if !exists("g:rust_recommended_style") || g:rust_recommended_style != 0
+if !get(g:, 'rust_recommended_style', 1)
 	setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab
 	setlocal textwidth=99
 endif
@@ -86,7 +86,7 @@ if exists("g:loaded_delimitMate")
 		\|endif
 endif
 
-if has("folding") && exists('g:rust_fold') && g:rust_fold != 0
+if has("folding") && get(g:, 'rust_fold', 0)
 	let b:rust_set_foldmethod=1
 	setlocal foldmethod=syntax
 	if g:rust_fold == 2
@@ -96,7 +96,7 @@ if has("folding") && exists('g:rust_fold') && g:rust_fold != 0
 	endif
 endif
 
-if has('conceal') && exists('g:rust_conceal') && g:rust_conceal != 0
+if has('conceal') && get(g:, 'rust_conceal', 0)
 	let b:rust_set_conceallevel=1
 	setlocal conceallevel=2
 endif


### PR DESCRIPTION
Just code cleanup. The expression `exists('g:x') && g:x != 0` (and variants) can be simplified to `get(g:, 'x', 0)`.