### PR TITLE
Add an option to let rustfmt 0.7 work

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -20,7 +20,7 @@ if !exists("g:rustfmt_fail_silently")
 endif
 
 if !exists("g:rustfmt_emit_files")
-	let g:rustfmt_emit_files = 0
+	let g:rustfmt_emit_files = 1 - (system("rustfmt --version") =~ "rustfmt 0.[0-6].\.*")
 endif
 
 let s:got_fmt_error = 0

--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -19,15 +19,29 @@ if !exists("g:rustfmt_fail_silently")
 	let g:rustfmt_fail_silently = 0
 endif
 
+if !exists("g:rustfmt_emit_files")
+	let g:rustfmt_emit_files = 0
+endif
+
 let s:got_fmt_error = 0
+
+function! s:RustfmtWriteMode()
+    if g:rustfmt_emit_files
+	    return "--emit=files"
+    else
+	    return "--write-mode=overwrite"
+    endif
+endfunction
 
 function! s:RustfmtCommandRange(filename, line1, line2)
 	let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
-	return printf("%s %s --write-mode=overwrite --file-lines '[%s]'", g:rustfmt_command, g:rustfmt_options, json_encode(l:arg))
+    let l:write_mode = s:RustfmtWriteMode()
+	return printf("%s %s %s --file-lines '[%s]'", g:rustfmt_command, l:write_mode, g:rustfmt_options, json_encode(l:arg))
 endfunction
 
 function! s:RustfmtCommand(filename)
-	return g:rustfmt_command . " --write-mode=overwrite " . g:rustfmt_options . " " . shellescape(a:filename)
+    let l:write_mode = s:RustfmtWriteMode()
+	return g:rustfmt_command . " ". l:write_mode . " " . g:rustfmt_options . " " . shellescape(a:filename)
 endfunction
 
 function! s:RunRustfmt(command, curw, tmpname)

--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -35,12 +35,12 @@ endfunction
 
 function! s:RustfmtCommandRange(filename, line1, line2)
 	let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
-    let l:write_mode = s:RustfmtWriteMode()
+	let l:write_mode = s:RustfmtWriteMode()
 	return printf("%s %s %s --file-lines '[%s]'", g:rustfmt_command, l:write_mode, g:rustfmt_options, json_encode(l:arg))
 endfunction
 
 function! s:RustfmtCommand(filename)
-    let l:write_mode = s:RustfmtWriteMode()
+	let l:write_mode = s:RustfmtWriteMode()
 	return g:rustfmt_command . " ". l:write_mode . " " . g:rustfmt_options . " " . shellescape(a:filename)
 endfunction
 

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -117,7 +117,8 @@ g:rustfmt_options~
 g:rustfmt_emit_files~
 	Set this option to 1 to run rustfmt with '--emit=files' instead of
 	'--write-mode=overwrite'. Necessary for rustfmt >= 0.7.0
-	If not specified it defaults to 0 : >
+	If not specified it defaults to 1 if rustfmt >= 0.7.0 is in $PATH or
+	zero otherwise : >
 	    let g:rustfmt_emit_files = 0
 <
 

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -113,6 +113,13 @@ g:rustfmt_options~
 	defaults to '' : >
 	    let g:rustfmt_options = ''
 <
+                                                       *g:rustfmt_emit_files*
+g:rustfmt_emit_files~
+	Set this option to 1 to run rustfmt with '--emit=files' instead of
+	'--write-mode=overwrite'. Necessary for rustfmt >= 0.7.0
+	If not specified it defaults to 0 : >
+	    let g:rustfmt_emit_files = 0
+<
 
                                                           *g:rust_playpen_url*
 g:rust_playpen_url~


### PR DESCRIPTION
Added an option to let this plugin work with both rustfmt < 0.6 and >=
0.7.

Fixes #212