### PR TITLE
Rustfmt not working on current nightly

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -23,11 +23,11 @@ let s:got_fmt_error = 0
 
 function! s:RustfmtCommandRange(filename, line1, line2)
 	let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
-	return printf("%s %s --write-mode=overwrite --file-lines '[%s]'", g:rustfmt_command, g:rustfmt_options, json_encode(l:arg))
+	return printf("%s %s --emit=files --file-lines '[%s]'", g:rustfmt_command, g:rustfmt_options, json_encode(l:arg))
 endfunction
 
 function! s:RustfmtCommand(filename)
-	return g:rustfmt_command . " --write-mode=overwrite " . g:rustfmt_options . " " . shellescape(a:filename)
+	return g:rustfmt_command . " --emit=files " . g:rustfmt_options . " " . shellescape(a:filename)
 endfunction
 
 function! s:RunRustfmt(command, curw, tmpname)


### PR DESCRIPTION
The issue was the use of an old flag compared to the new format: `--write-mode=overwrite` vs `--emit=files`
Fixed for current nightly, but I am not sure if this is the main error.

Please comment on the issue if it should be solved in another way.