### PR TITLE
Make vim quickfix aware of root directory of crate

### DIFF
--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -40,6 +40,8 @@ CompilerSet errorformat+=
 			\%Eerror[E%n]:\ %m,
 			\%Wwarning:\ %m,
 			\%Inote:\ %m,
+			\%D%\\s%#Checking\ %.%#(file://%f),
+			\%D%\\s%#Compiling\ %.%#(file://%f),
 			\%C\ %#-->\ %f:%l:%c
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
Previously, the quickfix window would be unaware of the current working directory. So if my cwd was `CRATEROOT/src` and quickfix parsed cargo's output as having an error at `src/mem.rs`, then I would be taken to `CRATEROOT/src/src/mem.rs`, which doesn't exist.

The changes I made make quickfix aware of the current directory so that error following now works in most cases. I haven't tested it, but this may be a fix for #196 and/or #210.

Notably, this is limited. The plugin will treat `Compiling/Checking CRATE v0.0.0 (file://PATH)` as a trigger that `PATH` is the cwd. But if several things are being compiled/checked at the same time, quickfix will just assume the most recent message is the cwd. This is not always correct. However, recompiling will often reduce the number of modules in the output to about 1. You can test out this functionality on any crate with local submodules (I used alacritty).