### PR TITLE
Use g:rustfmt_command for the version check

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -20,7 +20,7 @@ if !exists("g:rustfmt_fail_silently")
 endif
 
 if !exists("g:rustfmt_emit_files")
-	let g:rustfmt_emit_files = 1 - (system("rustfmt --version") =~ "rustfmt 0.[0-6].\.*")
+	let g:rustfmt_emit_files = 1 - (system(g:rustfmt_command . " --version") =~ "rustfmt 0.[0-6].\.*")
 endif
 
 let s:got_fmt_error = 0


### PR DESCRIPTION
As pointed out by @jonhoo in https://github.com/rust-lang/rust.vim/pull/213#discussion_r197833588 . We need to use the user specified command for all rustfmt invocations.