### PR TITLE
Match failed standard equality assertions in 'make test'

### DIFF
--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -40,7 +40,8 @@ CompilerSet errorformat+=
 			\%Eerror[E%n]:\ %m,
 			\%Wwarning:\ %m,
 			\%Inote:\ %m,
-			\%C\ %#-->\ %f:%l:%c
+			\%C\ %#-->\ %f:%l:%c,
+			\%E\ \ left:%m,%C\ right:%m\ %f:%l:%c,%Z
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
This change adds the error output of the `assert_eq!` to the
errorformat.

---- tests::testing stdout ----
        thread 'tests::testing' panicked at 'assertion failed: `(left == right)`
  left: `"World"`,
 right: `"Hello"`', src/main.rs:11:9

Fixes #225.