### PR TITLE
add path variable for cargo

### DIFF
--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -3,7 +3,8 @@ function! cargo#Load()
 endfunction
 
 function! cargo#cmd(args)
-    execute "! cargo" a:args
+    let cargo = exists("g:cargo_path") ? g:cargo_path : "cargo"
+    execute '!' . shellescape(cargo) . ' ' a:args
 endfunction
 
 function! s:nearest_cargo(...) abort

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -174,6 +174,13 @@ g:rust_clip_command~
 	    let g:rust_clip_command = 'xclip -selection clipboard'
 <
 
+                                                                *g:cargo_path*
+g:cargo_path~
+	Set this option to the path to cargo for use in the |:Cargo| and
+	|:Cbuild| commands. If unset, "cargo" will be located in $PATH: >
+	    let g:cargo_path = $HOME."/bin/cargo"
+<
+
 
 Integration with Syntastic                                    *rust-syntastic*
 --------------------------


### PR DESCRIPTION
use g:cargo_path to indicate cargo location. If not set, use cargo in the PATH.