### PR TITLE
indent: fix a cindent failure

### DIFF
--- a/indent/rust.vim
+++ b/indent/rust.vim
@@ -133,6 +133,9 @@ function GetRustIndent(lnum)
                 \ && prevline =~# '^\s*where\s'
         return indent(prevlinenum) + 6
     endif
+    if prevline[len(prevline) - 1] ==# "}" && cindent(a:lnum) == 0
+        return indent(prevlinenum)
+    endif
 
     if prevline[len(prevline) - 1] ==# ","
                 \ && s:get_line_trimmed(a:lnum) !~# '^\s*[\[\]{}]'


### PR DESCRIPTION
This commit attempts to fix what appears to be a failure mode in
cindent. Here's a minimal (but silly) example:

```
fn main() {
    if true {
{}
    }
}
```

In the above code, inserting a new line after the penultimate brace
dedents out to the first column instead of retaining the indent of the
previous line. The dedent to the first column persists regardless of the
nesting depth, e.g.,

```
fn main() {
    if true {
        if true {
{}
        }
    }
}
```

The behavior here is the same: inserting a new line after the
penultimate brace dedents the cursor back to the first column.

This example seems contrived, but the way I noticed it was in code that
roughly looked like this:

```
fn main() {
    if true {
        println!("
    Something happened:
{}
    ", "wat");
    }
}
```

in which the same failure mode persists.

This commit attempts to fix the issue by short-circuiting and using the
previous line's indent level when following two conditions are met:

    1. The last character of the previous line is a closing brace.
    2. cindent would otherwise dedent to the first column.

In this case, I claim that we always want to retain the indent of the
previous line (the closing brace). In the case where the correct dedent
is to the first column, then we retain that behavior because it should
imply that the indent of the previous line is itself the first column.

N.B. This is my first foray with investigating and attempting to fix an
indent bug in Vim. Please scrutinize carefully. :-)