### PR TITLE
fix: Prevent the rustfmt autocommand from triggering itself

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -146,7 +146,7 @@ function! s:RunRustfmt(command, tmpname, fail_silently)
             let l:content = readfile(a:tmpname)
         endif
 
-        call writefile(l:content, expand('%'))
+        call setline(1, l:content)
         silent edit!
         let &syntax = &syntax
 


### PR DESCRIPTION
Introduced in 2fb3df5, the writefile call would trigger the rustfmt
autocommand again if multiple Rust files were opened. setline prevents
this from happening and the `silent edit!` seems to be enough to remedy
the jump-to-start-of-file issue that 2fb3df5 fixed.

Fixes #245