### PR TITLE
Use setlocal over set to avoid messing up other file types

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -173,7 +173,7 @@ augroup rust.vim
                                     \|xunmap <buffer> ]]
                                     \|ounmap <buffer> [[
                                     \|ounmap <buffer> ]]
-                                    \|set matchpairs-=<:>
+                                    \|setlocal matchpairs-=<:>
                                     \|unlet b:match_skip
                                     \"
 
@@ -184,7 +184,7 @@ augroup rust.vim
 
 augroup END
 
-set matchpairs+=<:>
+setlocal matchpairs+=<:>
 " For matchit.vim (rustArrow stops `Fn() -> X` messing things up)
 let b:match_skip = 's:comment\|string\|rustArrow'
 


### PR DESCRIPTION
As a side note, this setting also messes with `<` and `>` as comparison operators. Anyway, I went with the obvious fix for now and left further improvements to the maintainers.