### PR TITLE
Document `g:cargo_makeprg_params`

### DIFF
--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -174,6 +174,13 @@ g:rust_clip_command~
 	    let g:rust_clip_command = 'xclip -selection clipboard'
 <
 
+                                                       *g:cargo_makeprg_params*
+g:cargo_makeprg_params~
+	Set this option to the string of parameters to pass to cargo. If not
+	specified it defaults to '$*' : >
+	    let g:cargo_makeprg_params = 'build'
+<
+
 
 Integration with Syntastic                                    *rust-syntastic*
 --------------------------


### PR DESCRIPTION
`g:cargo_makeprg_params` defaults to '$*' which with current versions of cargo
simply prints the help instructions. This option allows you to change that to
something more useful (like 'build').