### PR TITLE
b:rust_compiler_cargo_qf_prev_cd_saved not defined issue

### DIFF
--- a/autoload/cargo/quickfix.vim
+++ b/autoload/cargo/quickfix.vim
@@ -12,7 +12,7 @@ function! cargo#quickfix#CmdPre() abort
 endfunction
 
 function! cargo#quickfix#CmdPost() abort
-    if b:rust_compiler_cargo_qf_prev_cd_saved
+    if exists(b:rust_compiler_cargo_qf_prev_cd_saved) && b:rust_compiler_cargo_qf_prev_cd_saved
         " Restore the current directory.
         if b:rust_compiler_cargo_qf_has_lcd
             execute 'lchdir! '.b:rust_compiler_cargo_qf_prev_cd

--- a/autoload/cargo/quickfix.vim
+++ b/autoload/cargo/quickfix.vim
@@ -12,7 +12,7 @@ function! cargo#quickfix#CmdPre() abort
 endfunction
 
 function! cargo#quickfix#CmdPost() abort
-    if exists(b:rust_compiler_cargo_qf_prev_cd_saved) && b:rust_compiler_cargo_qf_prev_cd_saved
+    if exists("b:rust_compiler_cargo_qf_prev_cd_saved") && b:rust_compiler_cargo_qf_prev_cd_saved
         " Restore the current directory.
         if b:rust_compiler_cargo_qf_has_lcd
             execute 'lchdir! '.b:rust_compiler_cargo_qf_prev_cd


### PR DESCRIPTION
It's show b:rust_compiler_cargo_qf_prev_cd_saved not defined message when add blow content in vimrc
```
" open quickfix window at onece
autocmd QuickFixCmdPost [^l]* nested cwindow
autocmd QuickFixCmdPost    l* nested lwindow
```
