### PR TITLE
Fix `cwd` issues when using Neomake

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -146,8 +146,8 @@ function! s:RunRustfmt(command, tmpname, fail_silently)
             let l:content = readfile(a:tmpname)
         endif
 
-        call writefile(l:content, expand('%'))
-        silent edit!
+        normal! "_ggdG
+        call setline(1, l:content)
         let &syntax = &syntax
 
         " only clear location list if it was previously filled to prevent


### PR DESCRIPTION
All credit to @blueyed .

This fixes #260

The investigation is in the corresponding Neomake issue:
https://github.com/neomake/neomake/issues/2080

This is also related to: #259