### PR TITLE
Do not shorten playground URL when shortener is unavailable

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -412,16 +412,18 @@ function! rust#Play(count, line1, line2, ...) abort
         call setreg('"', save_regcont, save_regtype)
     endif
 
-    let body = l:rust_playpen_url."?code=".webapi#http#encodeURI(content)
+    let url = l:rust_playpen_url."?code=".webapi#http#encodeURI(content)
 
-    if strlen(body) > 5000
-        echohl ErrorMsg | echomsg 'Buffer too large, max 5000 encoded characters ('.strlen(body).')' | echohl None
+    if strlen(url) > 5000
+        echohl ErrorMsg | echomsg 'Buffer too large, max 5000 encoded characters ('.strlen(url).')' | echohl None
         return
     endif
 
-    let payload = "format=simple&url=".webapi#http#encodeURI(body)
+    let payload = "format=simple&url=".webapi#http#encodeURI(url)
     let res = webapi#http#post(l:rust_shortener_url.'create.php', payload, {})
-    let url = res.content
+    if res.status[0] ==# '2'
+        let url = res.content
+    endif
 
     if exists('g:rust_clip_command')
         call system(g:rust_clip_command, url)

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -425,11 +425,14 @@ function! rust#Play(count, line1, line2, ...) abort
         let url = res.content
     endif
 
+    let footer = ''
     if exists('g:rust_clip_command')
         call system(g:rust_clip_command, url)
+        if !v:shell_error
+            let footer = ' (copied to clipboard)'
+        endif
     endif
-
-    redraw | echomsg 'Done: '.url
+    redraw | echomsg 'Done: '.url.footer
 endfunction
 
 " }}}1


### PR DESCRIPTION
Now URL shortener seems down (500 response). In the case, `:RustPlay` does not work. Returned URL from the service is an empty string and the command does not report any errors.

This PR fixes the problem. Fortunately, shorten URL is optional. So it should check the response from URL shortener and when it failed, we can simply skip shortening.

This PR also adds a footer to output when the command copied a URL to clipboard since I always forget that URL was already copied and copy it manually 😳