### PR TITLE
Add support for 'cargo check --all-features'

### DIFF
--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -217,6 +217,14 @@ g:rust_cargo_check_all_targets~
 	package.
 	The default is 0.
 
+                                              *g:rust_cargo_check_all_features*
+                                              *b:rust_cargo_check_all_features*
+g:rust_cargo_check_all_features~
+	When set to 1, the `--all-features` option will be passed to cargo when
+	Syntastic executes it, allowing the linting of all features of the
+	package.
+	The default is 0.
+
                                                  *g:rust_cargo_check_examples*
                                                  *b:rust_cargo_check_examples*
 g:rust_cargo_check_examples~

--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -46,12 +46,14 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
     endif
 
     let l:check_all_targets = rust#GetConfigVar('rust_cargo_check_all_targets', 0)
+    let l:check_all_features = rust#GetConfigVar('rust_cargo_check_all_features', 0)
     let l:check_examples = rust#GetConfigVar('rust_cargo_check_examples', 0)
     let l:check_tests = rust#GetConfigVar('rust_cargo_check_tests', 0)
     let l:check_benches = rust#GetConfigVar('rust_cargo_check_benches', 0)
 
     let makeprg = makeprg. ' '
                 \  . (l:check_all_targets ? ' --all-targets' : '')
+                \  . (l:check_all_features ? ' --all-features' : '')
                 \  . (l:check_benches ? ' --benches' : '')
                 \  . (l:check_examples ? ' --examples' : '')
                 \  . (l:check_tests ? ' --tests' : '')


### PR DESCRIPTION
This PR adds support for the `--all-features` option of `cargo check`, which is required if the current project has code which is conditionally compiled depending on features, but we would still like to get syntax checking for said code.