### PR TITLE
Add :RustTest to run a test under the cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ If you set g:rust_clip_command RustPlay will copy the url to the clipboard.
 
         let g:rust_clip_command = 'xclip -selection clipboard'
 
+### Running a test under cursor
+
+In cargo project, the `:RustTest` command will run a test under the cursor.
+This is useful when your project is bigger and running all tests take longer time.
+
 ## Help
 
 Further help can be found in the documentation with `:Helptags` then `:help rust`.

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -406,6 +406,28 @@ functionality from other plugins.
 		Otherwise it is assumed rustc can be found in $PATH.
 
 
+Running test(s)
+---------------
+
+:RustTest[!] [options]                                          *:RustTest*
+		Runs a test under the cursor when the current buffer is in a
+		cargo project with "cargo test" command. If the command did
+		not find any test function under the cursor, it stops with an
+		error message.
+
+		When ! is given, runs all tests regardless of current cursor
+		position.
+
+		When [options] is given, it is passed to "cargo" command
+		arguments.
+
+		When the current buffer is outside cargo project, the command
+		runs "rustc --test" command instead of "cargo test" as
+		fallback. All tests are run regardless of adding ! since there
+		is no way to run specific test function with rustc. [options]
+		is passed to "rustc" command arguments in the case.
+
+
 rust.vim Debugging
 ------------------
 

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -135,6 +135,9 @@ augroup rust.vim
     " See |:RustInfoToFile| for docs
     command! -bar -nargs=1 RustInfoToFile call rust#debugging#InfoToFile(<f-args>)
 
+    " See |:RustTest| for docs
+    command! -buffer -nargs=* -bang RustTest call rust#Test(<bang>0, <q-args>)
+
     if !exists("b:rust_last_rustc_args") || !exists("b:rust_last_args")
         let b:rust_last_rustc_args = []
         let b:rust_last_args = []


### PR DESCRIPTION
I added a new command `:RustTest`.

From doc:

```
:RustTest[!] [options]                                          *:RustTest*
		Runs a test under the cursor when the current buffer is in a
		cargo project with "cargo test" command. If the command did
		not find any test function under the cursor, it stops with an
		error message.

 		When ! is given, runs all tests regardless of current cursor
		position.

 		When [options] is given, it is passed to "cargo" command
		arguments.

 		When the current buffer is outside cargo project, the command
		runs "rustc --test" command instead of "cargo test" as
		fallback. All tests are run regardless of adding ! since there
		is no way to run specific test function with rustc. [options]
		is passed to "rustc" command arguments in the case.
```

The motivation of this command is to run a test quickly and make test/fix loop faster. By running only test under the cursor, a developer can confirm the result of the specific test just after fixing it. This command is especially effective when a project is bigger and running all tests take longer time.