### PR TITLE
Create new syntax name for control flow keywords

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -24,17 +24,17 @@ syn keyword   rustOperator    as
 
 syn match     rustAssert      "\<assert\(\w\)*!" contained
 syn match     rustPanic       "\<panic\(\w\)*!" contained
-syn keyword   rustKeyword     break
+syn keyword   rustCtrlFlow    break
+syn keyword   rustCtrlFlow    continue
+syn keyword   rustCtrlFlow    return
+syn keyword   rustCtrlFlow    yield
 syn keyword   rustKeyword     box nextgroup=rustBoxPlacement skipwhite skipempty
-syn keyword   rustKeyword     continue
 syn keyword   rustKeyword     crate
 syn keyword   rustKeyword     extern nextgroup=rustExternCrate,rustObsoleteExternMod skipwhite skipempty
 syn keyword   rustKeyword     fn nextgroup=rustFuncName skipwhite skipempty
 syn keyword   rustKeyword     in impl let
 syn keyword   rustKeyword     macro
 syn keyword   rustKeyword     pub nextgroup=rustPubScope skipwhite skipempty
-syn keyword   rustKeyword     return
-syn keyword   rustKeyword     yield
 syn keyword   rustSuper       super
 syn keyword   rustKeyword     where
 syn keyword   rustUnsafeKeyword unsafe
@@ -287,6 +287,7 @@ hi def link rustFloat         Float
 hi def link rustArrowCharacter rustOperator
 hi def link rustOperator      Operator
 hi def link rustKeyword       Keyword
+hi def link rustCtrlFlow      Statement
 hi def link rustDynKeyword    rustKeyword
 hi def link rustTypedef       Keyword " More precise is Typedef, but it doesn't feel right for Rust
 hi def link rustStructure     Keyword " More precise is Structure


### PR DESCRIPTION
I'm writing a vim color scheme and I'd like to be able to differentiate `return`, `break`, `continue`, and similar keywords from "less important" keywords such as `let` or `impl`. Thus I added a new syntax type called `rustCtrlFlow` so color scheme authors can specifically target the control flow related keywords.