### PR TITLE
improve portability of RustTest command

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -443,12 +443,12 @@ function! s:SearchTestFunctionNameUnderCursor() abort
     let cursor_line = line('.')
 
     " Find #[test] attribute
-    if search('#\[test]', 'bcW') is 0
+    if search('\m\C#\[test\]', 'bcW') is 0
         return ''
     endif
 
     " Move to an opening brace of the test function
-    let test_func_line = search('^\s*fn\s\+\h\w*\s*(.\+{$', 'eW')
+    let test_func_line = search('\m\C^\s*fn\s\+\h\w*\s*(.\+{$', 'eW')
     if test_func_line is 0
         return ''
     endif
@@ -460,7 +460,7 @@ function! s:SearchTestFunctionNameUnderCursor() abort
         return ''
     endif
 
-    return matchstr(getline(test_func_line), '^\s*fn\s\+\zs\h\w*')
+    return matchstr(getline(test_func_line), '\m\C^\s*fn\s\+\zs\h\w*')
 endfunction
 
 function! rust#Test(all, options) abort
@@ -472,7 +472,8 @@ function! rust#Test(all, options) abort
     let pwd = shellescape(pwd)
 
     if a:all
-        execute '!cd ' . pwd . ' && cargo test ' . a:options
+        execute 'silent !cd' pwd
+        execute '!cargo test' a:options
         return
     endif
 
@@ -485,7 +486,8 @@ function! rust#Test(all, options) abort
             echohl None
             return
         endif
-        execute '!cd ' . pwd . ' && cargo test ' . func_name . ' ' . a:options
+        execute 'silent !cd' pwd
+        execute '!cargo test' func_name a:options
     finally
         call setpos('.', saved)
     endtry


### PR DESCRIPTION
The RustTest command added in #267 is super useful! I updated rust.vim and tried to use it and ran into some issues with my (admittedly unusual) system configuration.

I use `set nomagic` in my `.vimrc`, so the regex to search for `#\[test]` was searching for the literal string `#\[test]`, backslash including. Prefixing the regex with `\m\C` ensures we are using magic and matching case (i.e. ignoring the user's custom `magic` and `ignorecase` settings). This is recommended by [Google's Vimscript style guide](https://google.github.io/styleguide/vimscriptguide.xml?showone=Regular_Expressions#Regular_Expressions).

I also use [fish](https://fishshell.com/) as my shell, which does not support the `&&` operator. I separated the two commands to be on separate lines, which allows fish users to take advantage of this feature. I don't think this should affect users of other shells, though I would appreciate someone verifying this belief.

@rhysd can you check over my changes and make sure I didn't affect any of the functionality? Thank you :)