### PR TITLE
rustfmt.vim: --write-mode=overwrite is not recognized anymore

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -56,7 +56,7 @@ function! s:RustfmtWriteMode()
     if g:rustfmt_emit_files
         return "--emit=files"
     else
-        return "--write-mode=overwrite"
+        return ""
     endif
 endfunction
 


### PR DESCRIPTION
rustfmt (stable) does not recognize the option '--write-mode=overwrite'. This change makes :RustFmt work again for stable.