### PR TITLE
Remove incorrect rustfmt version check

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -22,7 +22,7 @@ endif
 function! rustfmt#DetectVersion()
     " Save rustfmt '--help' for feature inspection
     silent let s:rustfmt_help = system(g:rustfmt_command . " --help")
-    let s:rustfmt_unstable_features = 1 - (s:rustfmt_help !~# "--unstable-features")
+    let s:rustfmt_unstable_features = s:rustfmt_help =~# "--unstable-features"
 
     " Build a comparable rustfmt version varible out of its `--version` output:
     silent let l:rustfmt_version_full = system(g:rustfmt_command . " --version")
@@ -43,7 +43,7 @@ if !exists("g:rustfmt_emit_files")
 endif
 
 if !exists("g:rustfmt_file_lines")
-    let g:rustfmt_file_lines = 1 - (s:rustfmt_help !~# "--file-lines JSON")
+    let g:rustfmt_file_lines = s:rustfmt_help =~# "--file-lines JSON"
 endif
 
 let s:got_fmt_error = 0

--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -84,11 +84,9 @@ function! s:RustfmtCommandRange(filename, line1, line2)
     let l:write_mode = s:RustfmtWriteMode()
     let l:rustfmt_config = s:RustfmtConfig()
 
-    " FIXME: When --file-lines gets to be stable, enhance this version range checking
+    " FIXME: When --file-lines gets to be stable, add version range checking
     " accordingly.
-    let l:unstable_features = 
-                \ (s:rustfmt_unstable_features && (s:rustfmt_version < '1.'))
-                \ ? '--unstable-features' : ''
+    let l:unstable_features = s:rustfmt_unstable_features ? '--unstable-features' : ''
 
     let l:cmd = printf("%s %s %s %s %s --file-lines '[%s]' %s", g:rustfmt_command,
                 \ l:write_mode, g:rustfmt_options,


### PR DESCRIPTION
There was a version check in `rusfmt.vim` to determine if `--unstable-features` should be passed to `rustfmt` or not. This PR removes that check. The check seems to assume that with 1.0 the `--file-lines` feature is stabilized, but it is not:

```
$ rustfmt -V
rustfmt 1.0.1-nightly (be13559 2018-12-10)
$ rustfmt --file-lines ''
Unstable option (`--file-lines`) used without `--unstable-features`
```

Additionally, this PR replaces the rather odd `1 - (foo !~# bar)` pattern with simply `foo =~# bar`. I asked around at #vim on freenode, nobody could give me a valid reason for the former.