### PR TITLE
Improve 'async' contextual keyword highlighting

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -26,7 +26,7 @@ syn match rustExistentialContextual /\<existential\_s\+type/ transparent contain
 
 syn match     rustAssert      "\<assert\(\w\)*!" contained
 syn match     rustPanic       "\<panic\(\w\)*!" contained
-syn keyword   rustKeyword     async
+syn match     rustKeyword     "\<async\%(\s\|\n\)\@="
 syn keyword   rustKeyword     break
 syn keyword   rustKeyword     box nextgroup=rustBoxPlacement skipwhite skipempty
 syn keyword   rustKeyword     continue


### PR DESCRIPTION
`async` is a contextual keyword. For example, when it is used in context of scope resolution (`::`), `async` can be used as module name. In the case, the `async` name should be highlighted as normal identifier, not a keyword.

This patch restricts highlighting `async` as keyword only when space or newline is following. So now `async` in module resolution such as `foo::async::X` is highlighted as normal module name.

Here is a screenshot:

![2018-12-20 11 51 12](https://user-images.githubusercontent.com/823277/50261054-1c48bd00-044e-11e9-9f63-cd1b61cb2e3c.png)
