### PR TITLE
Use :terminal for running tests on :RustTest

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -468,10 +468,20 @@ function! rust#Test(all, options) abort
     if manifest ==# ''
         return rust#Run(1, '--test ' . a:options)
     endif
-    let manifest = shellescape(manifest)
+
+    if exists(':terminal')
+        let cmd = 'terminal '
+    else
+        let cmd = '!'
+        let manifest = shellescape(manifest)
+    endif
 
     if a:all
-        execute '!cargo test --manifest-path' manifest a:options
+        if a:options ==# ''
+            execute cmd . 'cargo test --manifest-path' manifest
+        else
+            execute cmd . 'cargo test --manifest-path' manifest a:options
+        endif
         return
     endif
 
@@ -484,7 +494,11 @@ function! rust#Test(all, options) abort
             echohl None
             return
         endif
-        execute '!cargo test --manifest-path' manifest func_name a:options
+        if a:options ==# ''
+            execute cmd . 'cargo test --manifest-path' manifest func_name
+        else
+            execute cmd . 'cargo test --manifest-path' manifest func_name a:options
+        endif
         return
     finally
         call setpos('.', saved)


### PR DESCRIPTION
Currently `:RustTest` runs tests with `:!`. However, it uses entire screen. We cannot check the results and Vim buffer at the same time.

Neovim and Vim 8+ now has a terminal and `:terminal` can start a command in the terminal. I prefer it to `:!`.

This patch uses `:terminal` for running `cargo test` if possible.