### PR TITLE
Set `include` and improve `includeexpr`

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Chris Morgan <me@chrismorgan.info>
 " Maintainer:   Kevin Ballard <kevin@sb.org>
 " Last Change:  June 08, 2016
-" For bugs, patches and license go to https://github.com/rust-lang/rust.vim 
+" For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("b:did_ftplugin")
     finish
@@ -52,8 +52,14 @@ if get(g:, 'rust_recommended_style', 1)
     setlocal textwidth=99
 endif
 
-" This includeexpr isn't perfect, but it's a good start
-setlocal includeexpr=substitute(v:fname,'::','/','g')
+" The following line changes a global variable but is necessary to make [i and
+" similar commands work. If this causes a problem for you, add an
+" after/ftplugin/rust.vim file that contains
+"       set isfname-=:
+set isfname+=:
+
+setlocal include=^\\s*use
+setlocal includeexpr=rust#IncludeExpr(v:fname)
 
 setlocal suffixesadd=.rs
 
@@ -147,7 +153,7 @@ endif
 " Cleanup {{{1
 
 let b:undo_ftplugin = "
-            \ setlocal formatoptions< comments< commentstring< includeexpr< suffixesadd<
+            \ setlocal formatoptions< comments< commentstring< include< includeexpr< suffixesadd<
             \|if exists('b:rust_set_style')
                 \|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
                 \|endif

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -58,7 +58,7 @@ endif
 "       set isfname-=:
 set isfname+=:
 
-setlocal include=^\\s*use
+setlocal include=^\\s*\\(pub\\s\\+\\)\\?use
 setlocal includeexpr=rust#IncludeExpr(v:fname)
 
 setlocal suffixesadd=.rs

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -52,13 +52,7 @@ if get(g:, 'rust_recommended_style', 1)
     setlocal textwidth=99
 endif
 
-" The following line changes a global variable but is necessary to make [i and
-" similar commands work. If this causes a problem for you, add an
-" after/ftplugin/rust.vim file that contains
-"       set isfname-=:
-set isfname+=:
-
-setlocal include=^\\s*\\(pub\\s\\+\\)\\?use
+setlocal include=\\v^\\s*(pub\\s+)?use\\s+\\zs(\\f\|:)+
 setlocal includeexpr=rust#IncludeExpr(v:fname)
 
 setlocal suffixesadd=.rs


### PR DESCRIPTION
Improved cross-file search:

- recognise `use crate::foo::bar::baz` as being an 'include' statement
- enhance `includeexpr` to handle 2018 edition, among other things

it's a bit unfortunate that `isfname` is a global variable in vim; I've followed the lead of the perl plugin, [here](https://github.com/vim/vim/blob/6436cd83f90a0efc326798792e49e8ff96a43dce/runtime/ftplugin/perl.vim#L38-L43) in setting it anyway.

(I suppose most people use RLS for this sort of thing, and that is mostly superior.  But maybe that's not always available for one reason or another; and anyway, I see no reason not to let Vim do its best).