### PR TITLE
Fix auto format on save don't work when switch buffer

### DIFF
--- a/autoload/cargo/quickfix.vim
+++ b/autoload/cargo/quickfix.vim
@@ -12,7 +12,7 @@ function! cargo#quickfix#CmdPre() abort
 endfunction
 
 function! cargo#quickfix#CmdPost() abort
-    if b:rust_compiler_cargo_qf_prev_cd_saved
+    if exists(b:rust_compiler_cargo_qf_prev_cd_saved) && b:rust_compiler_cargo_qf_prev_cd_saved
         " Restore the current directory.
         if b:rust_compiler_cargo_qf_has_lcd
             execute 'lchdir! '.b:rust_compiler_cargo_qf_prev_cd

--- a/autoload/cargo/quickfix.vim
+++ b/autoload/cargo/quickfix.vim
@@ -12,7 +12,7 @@ function! cargo#quickfix#CmdPre() abort
 endfunction
 
 function! cargo#quickfix#CmdPost() abort
-    if exists(b:rust_compiler_cargo_qf_prev_cd_saved) && b:rust_compiler_cargo_qf_prev_cd_saved
+    if exists("b:rust_compiler_cargo_qf_prev_cd_saved") && b:rust_compiler_cargo_qf_prev_cd_saved
         " Restore the current directory.
         if b:rust_compiler_cargo_qf_has_lcd
             execute 'lchdir! '.b:rust_compiler_cargo_qf_prev_cd

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -173,7 +173,7 @@ augroup rust.vim
                                     \|xunmap <buffer> ]]
                                     \|ounmap <buffer> [[
                                     \|ounmap <buffer> ]]
-                                    \|set matchpairs-=<:>
+                                    \|setlocal matchpairs-=<:>
                                     \|unlet b:match_skip
                                     \"
 
@@ -184,7 +184,7 @@ augroup rust.vim
 
 augroup END
 
-set matchpairs+=<:>
+setlocal matchpairs+=<:>
 " For matchit.vim (rustArrow stops `Fn() -> X` messing things up)
 let b:match_skip = 's:comment\|string\|rustArrow'
 

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -186,7 +186,7 @@ let b:undo_ftplugin = "
 " Code formatting on save
 augroup rust.vim.PreWrite
     autocmd!
-    autocmd BufWritePre <buffer> silent! call rustfmt#PreWrite()
+    autocmd BufWritePre *.rs silent! call rustfmt#PreWrite()
 augroup END
 
 setlocal matchpairs+=<:>


### PR DESCRIPTION
Produce this issue:

```
1) open main.rs
2) :e new.rs 
3) :bp switch back main.rs
4) edit and :w, auto format don't work
```
