### PR TITLE
Update the documentation to clarify Vim 8 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 This is a Vim plugin that provides [Rust][r] file detection, syntax highlighting, formatting,
-[Syntastic][syn] integration, and more.
+[Syntastic][syn] integration, and more. It requires Vim 8 or higher.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a Vim plugin that provides [Rust][r] file detection, syntax highlighting, formatting,
 [Syntastic][syn] integration, and more. It requires Vim 8 or higher for full functionality.
-Some things man not work on earlier versions. 
+Some things may not work on earlier versions. 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ## Description
 
 This is a Vim plugin that provides [Rust][r] file detection, syntax highlighting, formatting,
-[Syntastic][syn] integration, and more. It requires Vim 8 or higher.
+[Syntastic][syn] integration, and more. It requires Vim 8 or higher for full functionality.
+Some things man not work on earlier versions. 
 
 ## Installation
 

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -12,7 +12,7 @@ CONTENTS                                                      *rust*
 INTRODUCTION                                                      *rust-intro*
 
 This plugin provides syntax and supporting functionality for the Rust
-filetype. To fuction properly, it requires Vim 8 or higher. Some commands
+filetype. It requires Vim 8 or higher for full functionality. Some commands
 will not work on earlier versions.
 
 ==============================================================================

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -12,7 +12,8 @@ CONTENTS                                                      *rust*
 INTRODUCTION                                                      *rust-intro*
 
 This plugin provides syntax and supporting functionality for the Rust
-filetype.
+filetype. To fuction properly, it requires Vim 8 or higher. Some commands
+will not work on earlier versions.
 
 ==============================================================================
 SETTINGS                                                       *rust-settings*


### PR DESCRIPTION
Clarifies that Vim 8 is necessary for the plugin to work correctly. When installing, I spent several hours trying figure out why certain commands weren't working. It turns out the problem was that I was using Vim 7.1, but I couldn't find the version 8 requirement anywhere in the documentation. These small changes clarify the issue so others don't have this problem.