### PR TITLE
Include entries starting with ":::" in quickfix window.

### DIFF
--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -34,6 +34,7 @@ CompilerSet errorformat=
             \%Wwarning:\ %m,
             \%Inote:\ %m,
             \%C\ %#-->\ %f:%l:%c,
+            \%C\ %#:::\ %f:%l:%c,
             \%E\ \ left:%m,%C\ right:%m\ %f:%l:%c,%Z
 
 " Old errorformat (before nightly 2016/08/10)

--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -75,7 +75,8 @@ function! SyntaxCheckers_rust_cargo_GetLocList() dict
                 \ '%Eerror[E%n]: %m,' .
                 \ '%Wwarning: %m,' .
                 \ '%Inote: %m,' .
-                \ '%C %#--> %f:%l:%c'
+                \ '%C %#--> %f:%l:%c' .
+                \ '%C %#::: %f:%l:%c'
 
     return SyntasticMake({
                 \ 'makeprg': makeprg,

--- a/syntax_checkers/rust/rustc.vim
+++ b/syntax_checkers/rust/rustc.vim
@@ -35,7 +35,8 @@ function! SyntaxCheckers_rust_rustc_GetLocList() dict
                 \ '%-Gwarning: the option `Z` is unstable %.%#,' .
                 \ '%Wwarning: %m,' .
                 \ '%Inote: %m,' .
-                \ '%C %#--> %f:%l:%c'
+                \ '%C %#--> %f:%l:%c' .
+                \ '%C %#::: %f:%l:%c'
 
     return SyntasticMake({
                 \ 'makeprg': makeprg,


### PR DESCRIPTION
Currently, the `errorformat` does not match additional files mentioned in a
compilation error.

In the following example, only the first file mentioned is matched (`src/node4.rs`, line 118, column 1):

```
error[E0046]: not all trait items implemented, missing: `children`
   --> src/node4.rs:118:1
    |
118 | impl<'a, T> NodeImpl<'a, T> for Node4<'a, T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `children` in implementation
    |
   ::: src/lib.rs:134:5
    |
134 |     fn children(&self) -> Box<dyn Iterator<Item=(u8, &'a Child<'a, T>)> + 'a>;
    |     -------------------------------------------------------------------------- `children` from trait
```

This pull-request will include the second file mentioned (`src/lib.rs`, line 134, column 5).