### PR TITLE
ftdetect: Use `setf FALLBACK` to set Cargo.toml filetype

### DIFF
--- a/ftdetect/rust.vim
+++ b/ftdetect/rust.vim
@@ -1,6 +1,6 @@
 " vint: -ProhibitAutocmdWithNoGroup
 
 autocmd BufRead,BufNewFile *.rs setf rust
-autocmd BufRead,BufNewFile Cargo.toml if &filetype == "" | set filetype=cfg | endif
+autocmd BufRead,BufNewFile Cargo.toml setf FALLBACK cfg
 
 " vim: set et sw=4 sts=4 ts=8:


### PR DESCRIPTION
[vim-toml recently started using `setf`.][1] As a result, the filetype set by rust.vim is no longer overridden. 
Use `setf FALLBACK` as this is the proper mechanism for uncertain filetypes.

[1]: https://github.com/cespare/vim-toml/commit/d257faaa32ffee1794038f2342ba315760c33fc2