### PR TITLE
Add additional check before rustfmt is called

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -230,6 +230,9 @@ function! rustfmt#Cmd()
 endfunction
 
 function! rustfmt#PreWrite()
+    if !filereadable(expand("%@"))
+        return
+    endif
     if rust#GetConfigVar('rustfmt_autosave_if_config_present', 0)
         if findfile('rustfmt.toml', '.;') !=# '' || findfile('.rustfmt.toml', '.;') !=# ''
             let b:rustfmt_autosave = 1


### PR DESCRIPTION
The auto format mechanism of the plugin fails for unreadable .rs files.
Such unreadable sudo files are for example used by other plugins like
fugitive to implement some of their features (see related issues).
Therefore plugins/mechansims releying on this sudo files currently can't be
used while auto formatting is active.

In order to fix this kind of issues and additional pre format check is added.

Related Issues:
* https://github.com/tpope/vim-fugitive/issues/1128

Related PR's:
* https://github.com/hashivim/vim-terraform/pull/83