### PR TITLE
Restore cwd on rustfmt failure before opening lwindow

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -145,6 +145,7 @@ function! s:RunRustfmt(command, tmpname, fail_silently)
 
     call delete(l:stderr_tmpname)
 
+    let l:open_lwindow = 0
     if v:shell_error == 0
         " remove undo point caused via BufWritePre
         try | silent undojoin | catch | endtry
@@ -165,7 +166,7 @@ function! s:RunRustfmt(command, tmpname, fail_silently)
         if s:got_fmt_error
             let s:got_fmt_error = 0
             call setloclist(0, [])
-            lwindow
+            let l:open_lwindow = 1
         endif
     elseif g:rustfmt_fail_silently == 0 && a:fail_silently == 0
         " otherwise get the errors and put them in the location list
@@ -197,7 +198,7 @@ function! s:RunRustfmt(command, tmpname, fail_silently)
         endif
 
         let s:got_fmt_error = 1
-        lwindow
+        let l:open_lwindow = 1
     endif
 
     " Restore the current directory if needed
@@ -207,6 +208,11 @@ function! s:RunRustfmt(command, tmpname, fail_silently)
         else
             execute 'chdir! '.l:prev_cd
         endif
+    endif
+
+    " Open lwindow after we have changed back to the previous directory
+    if l:open_lwindow == 1
+        lwindow
     endif
 
     silent! loadview


### PR DESCRIPTION
If rustfmt fails RunRustFmt helpfully opens the lwindow to show
the errors rustfmt encountered.
The 'lwindow' command opens the location list window, and makes that
the active vim window.

Before rustfmt is executed RunRustFmt change CWD to the directory
where the file to be formated resides. CWD is restored before exiting
RunRustFmt.

The problem was that location list window was opened before restoring
CWD, which meant that we only restored the directory of the lwindow.
The window holding the formatted rust file is left with CWD of that
file.

The obvious solution is to restore the CWD *before* opening the
location list window.