### PR TITLE
Improve filetype setting

### DIFF
--- a/ftdetect/rust.vim
+++ b/ftdetect/rust.vim
@@ -1,6 +1,12 @@
 " vint: -ProhibitAutocmdWithNoGroup
 
-autocmd BufRead,BufNewFile *.rs setf rust
+autocmd BufRead,BufNewFile *.rs call s:set_rust_filetype()
 autocmd BufRead,BufNewFile Cargo.toml setf FALLBACK cfg
+
+function! s:set_rust_filetype() abort
+    if &filetype !=# 'rust'
+        set filetype=rust
+    endif
+endfunction
 
 " vim: set et sw=4 sts=4 ts=8:


### PR DESCRIPTION
- `:set filetype` forces a filetype.
- `:setfiletype` only sets a filetype if it didn't already happen earlier due to
the same event.

Current versions of Vim and Neovim have a `$VIMRUNTIME/filetype.vim` that sets
the `rust` filetype for all files with an `.rs` extension.

This plugin did that with `set filetype=rust` as well. But now, with the
filetype getting set twice, `ftplugin/rust/*` was sourced twice as well.

This got fixed in https://github.com/rust-lang/rust.vim/pull/301 by changing
`set filetype=rust` to `setfiletype rust`.

But that fix introduced a regression for all older Vim versions. There is still
a lot of Vim 7.4 around and Debian stable still provides Nvim 0.1.7, both being
very old versions.

The `$VIMRUNTIME/filetype.vim` of these old versions set the filetype to
`hercules` for all `.rs` files via `setfiletype hercules`.

Now, usually (it also depends on how plugins gets sourced) `filetype.vim` gets
sourced _before_ any `ftdetect/*` files from plugins. And since autocmds are
processed in order, Vim would first do `setfiletype hercules` and so any
subsequent `setfiletype rust` fails.

The obvious solution: Force the `rust` filetype for all `.rs` extensions unless
the filetype is already set to `rust`.

So, we have the filetype setting working again for older versions and also avoid
setting the filetype twice.

Fixes https://github.com/rust-lang/rust.vim/issues/306
Fixes https://github.com/rust-lang/rust.vim/issues/318