### PR TITLE
Allow attributes to contain nested brackets.

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -149,7 +149,12 @@ syn region    rustString      start=+b"+ skip=+\\\\\|\\"+ end=+"+ contains=rustE
 syn region    rustString      start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=rustEscape,rustEscapeUnicode,rustEscapeError,rustStringContinuation,@Spell
 syn region    rustString      start='b\?r\z(#*\)"' end='"\z1' contains=@Spell
 
-syn region    rustAttribute   start="#!\?\[" end="\]" contains=rustString,rustDerive,rustCommentLine,rustCommentBlock,rustCommentLineDocError,rustCommentBlockDocError
+" Match attributes with either arbitrary syntax or special highlighting for     
+" derives. We still highlight strings and comments inside of the attribute.     
+syn region    rustAttribute   start="#!\?\[" end="\]" contains=@rustAttributeContents,rustAttributeParenthesized,rustAttributeKeyValue,rustDerive
+syn region    rustAttributeParenthesized matchgroup=rustAttribute start="\w\%(\w\)*("rs=e end=")"re=s transparent contained contains=rustAttributeBalanced,@rustAttributeContents
+syn region    rustAttributeBalanced matchgroup=rustAttribute start="("rs=e end=")"re=s transparent contained contains=rustAttributeBalanced,@rustAttributeContents
+syn cluster   rustAttributeContents contains=rustString,rustCommentLine,rustCommentBlock,rustCommentLineDocError,rustCommentBlockDocError
 syn region    rustDerive      start="derive(" end=")" contained contains=rustDeriveTrait
 " This list comes from src/libsyntax/ext/deriving/mod.rs
 " Some are deprecated (Encodable, Decodable) or to be removed after a new snapshot (Show).


### PR DESCRIPTION
With Rust 1.34, proc-macro attributes now accept arbitrary tokens as arguments, allowing a user to write an attribute e.g. `#[my_attribute(a = [1, 2, 3], b = ("x", "y", "z")]`
The previous attribute highlighter would stop at the first `]`, leaving a lot of the attribute unhighlighted. This patch changes the highlighter to be more robust to nested brackets and parentheses.

As before, only derives, comments, and strings get special formatting inside of an attribute. It may make more sense to allow arbitrary syntax highlighting inside of the attribute arguments, but that's outside the scope of this patch.

Fixes #320