### PR TITLE
Try moving the cursor back after running rustfmt.

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -111,6 +111,7 @@ function! s:DeleteLines(start, end) abort
 endfunction
 
 function! s:RunRustfmt(command, tmpname, fail_silently)
+    let l:current_position = getpos('.')
     mkview!
 
     let l:stderr_tmpname = tempname()
@@ -216,6 +217,7 @@ function! s:RunRustfmt(command, tmpname, fail_silently)
     endif
 
     silent! loadview
+    call setpos('.', l:current_position)
 endfunction
 
 function! rustfmt#FormatRange(line1, line2)


### PR DESCRIPTION
I set `let g:rustfmt_autosave = 1`, so the cursor moves to the end of file after I saved it every time.

I'm tired to do move the cursor back manually.
Temporarily, I add this trigger to `autocmd BufWritePre` and `autocmd BufWritePost`.

But, I think add this trigger to the function which moves the the cursor is a better choice.