### PR TITLE
Don't change user's formatoptions

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -38,9 +38,6 @@ else
     setlocal comments=s0:/*!,m:\ ,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
 endif
 setlocal commentstring=//%s
-setlocal formatoptions-=t formatoptions+=croqnl
-" j was only added in 7.3.541, so stop complaints about its nonexistence
-silent! setlocal formatoptions+=j
 
 " smartindent will be overridden by indentexpr if filetype indent is on, but
 " otherwise it's better than nothing.


### PR DESCRIPTION
I've hit a bug in which hitting enter it will insert a comment start, any word that overflowed the previous line and set the cursor to the start of the line (before the comment start).

Which result in some amazing stuff like:

```rust 
// Some awesome long
ent. // comm
```

(It should say "Some awesome long comment.")

This change remove setting the formatoptions for the user, if you use Vim you can decide this for yourself.