### PR TITLE
Highlight delimiters

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -137,6 +137,7 @@ syn match     rustOperator     display "&&\|||"
 " so it skips the ->; see http://stackoverflow.com/a/30309949 for details.
 syn match     rustArrowCharacter display "->"
 syn match     rustQuestionMark display "?\([a-zA-Z]\+\)\@!"
+syn match     rustDelimiter    "[(){}\[\];]"
 
 syn match     rustMacro       '\w\(\w\)*!' contains=rustAssert,rustPanic
 syn match     rustMacro       '#\w\(\w\)*' contains=rustAssert,rustPanic
@@ -335,6 +336,7 @@ hi def link rustExternCrate   rustKeyword
 hi def link rustObsoleteExternMod Error
 hi def link rustBoxPlacementParens Delimiter
 hi def link rustQuestionMark  Special
+hi def link rustDelimiter     Delimiter
 
 " Other Suggestions:
 " hi rustAttribute ctermfg=cyan


### PR DESCRIPTION
Previously delimiters such as `{` and `}` were left unhighlighted.