### PR TITLE
use default tagbar settings with universal ctags

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ for more details.
 
 ### Source browsing with [Tagbar][tgbr]
 
-`rust.vim` has builtin `ctags/` definitions for [Tagbar][tgbr] which
-are loaded if Tagbar is installed.
+The installation of Tagbar along with [Universal Ctags](uctags) is recommended
+for a good Tagbar experience. For other kinds of setups, `rust.vim` tries to
+configure Tagbar to some degree.
 
 ### Formatting with [rustfmt][rfmt]
 
@@ -102,6 +103,7 @@ LICENSE-MIT for details.
 [rfmt]: https://github.com/rust-lang-nursery/rustfmt
 [syn]: https://github.com/scrooloose/syntastic
 [tgbr]: https://github.com/majutsushi/tagbar
+[uctags]: https://ctags.io
 [wav]: https://github.com/mattn/webapi-vim
 [pp]: https://play.rust-lang.org/
 [vim8pack]: http://vimhelp.appspot.com/repeat.txt.html#packages

--- a/autoload/rust/tags.vim
+++ b/autoload/rust/tags.vim
@@ -1,0 +1,17 @@
+" Tagbar support code, for the sake of not automatically overriding its
+" configuration in case Universal Ctags is detected.
+
+let s:ctags_is_uctags = 0
+let s:checked_ctags = 0
+
+function! rust#tags#IsUCtags() abort
+    if s:checked_ctags == 0
+        if system('ctags --version') =~? 'universal ctags'
+            let s:ctags_is_uctags = 1
+        endif
+        let s:checked_ctags = 1
+    endif
+    return s:ctags_is_uctags
+endfunction
+
+" vim: set et sw=4 sts=4 ts=8:

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -91,12 +91,17 @@ g:rust_use_custom_ctags_defs~
 	and do not wish for those included with rust.vim to be used: >
 	    let g:rust_use_custom_ctags_defs = 1
 <
-	Note that rust.vim's built-in definitions are only used for the Tagbar
-	Vim plugin, if you have it installed--it is not automatically used
-	when generating |tags| files that Vim can use to navigate to
-	definitions across different source files. Feel free to copy
-	`rust.vim/ctags/rust.ctags` into your own `~/.ctags` if you wish to
-	generate |tags| files.
+
+	NOTE: rust.vim's built-in definitions are only used for the Tagbar Vim
+	plugin, if you have it installed, AND if Universal Ctags is not
+	detected. This is because Universal Ctags already has built-in
+	support for Rust when used with Tagbar.
+
+	Also, note that when using ctags other than Universal Ctags, it is not
+	automatically used when generating |tags| files that Vim can use to
+	navigate to definitions across different source files. Feel free to
+	copy `rust.vim/ctags/rust.ctags` into your own `~/.ctags` if you wish
+	to generate |tags| files.
 
 
                                                  *g:ftplugin_rust_source_path*

--- a/ftplugin/rust/tagbar.vim
+++ b/ftplugin/rust/tagbar.vim
@@ -1,7 +1,7 @@
 "
 " Support for Tagbar -- https://github.com/majutsushi/tagbar
 "
-if !exists(':Tagbar') || system('ctags --version') =~? 'universal ctags'
+if !exists(':Tagbar') || rust#tags#IsUCtags()
     finish
 endif
 

--- a/ftplugin/rust/tagbar.vim
+++ b/ftplugin/rust/tagbar.vim
@@ -1,7 +1,7 @@
 "
 " Support for Tagbar -- https://github.com/majutsushi/tagbar
 "
-if !exists(':Tagbar')
+if !exists(':Tagbar') || system('ctags --version') =~? 'universal ctags'
     finish
 endif
 


### PR DESCRIPTION
I'm not sure this is the best way to do this, but using the settings in this plugin will break Tagbar with Universal Ctags (see #313). [Tagbar already has more complete ctags definitions](https://github.com/majutsushi/tagbar/blob/master/autoload/tagbar/types/uctags.vim#L784-L820) for Universal Ctags than the settings here.