### PR TITLE
Fix joining comment line removes // comment leader

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -35,7 +35,7 @@ if get(g:, 'rust_bang_comment_leader', 0)
     " leaders. I'm fairly sure that's a Vim bug.
     setlocal comments=s1:/*,mb:*,ex:*/,s0:/*,mb:\ ,ex:*/,:///,://!,://
 else
-    setlocal comments=s0:/*!,m:\ ,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
+    setlocal comments=s0:/*!,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
 endif
 setlocal commentstring=//%s
 setlocal formatoptions-=t formatoptions+=croqnl


### PR DESCRIPTION
Fixes #336, #78 

The root cause of #336 and #78 is that the line joined with comment line is wrongly regarded as comment line. Vim uses `comments` option to check if the line is comment or not. And in `ftplugin/rust.vim`, it is set to include

```
m:\ ,
```

It means that a line starts with one space is middle of block comment. So Vim wrongly regards any line which starts with space as comment line.

```
    A
    // B
```

When joining a comment line `// B` into `A` with `J`, Vim regards `A` line is a comment line. So it removes `//` from `// B` to join two comment lines.

I don't know why `m:\ ` was included in `comments` option, but it looks some mistake for me. So this patch removes the config and after that, `J` will work fine fixing #336 and #78.