### PR TITLE
fix 'RustTest' fail when vim build with feature `-terminal`

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -505,7 +505,7 @@ function! rust#Test(all, options) abort
         return rust#Run(1, '--test ' . a:options)
     endif
 
-    if exists(':terminal')
+    if has('terminal')
         let cmd = 'terminal '
     else
         let cmd = '!'


### PR DESCRIPTION
error screen:
![image](https://user-images.githubusercontent.com/282373/63413430-44991900-c42c-11e9-9a76-3b842d07c70f.png)


when VIM build with feature `terminal` off, the command `:terminal` is still available but report error. So, check the feature with `has()` instead `exists()`

:version report
![image](https://user-images.githubusercontent.com/282373/63413040-84abcc00-c42b-11e9-80e4-23b9e959b5d3.png)

:terminal output
```
:terminal
E319: Sorry, the command is not available in this version

:echo has('terminal')
0

:echo exists(':terminal')
2
```
