### PR TITLE
add missing test message to message-history

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -526,7 +526,7 @@ function! rust#Test(all, options) abort
         let func_name = s:SearchTestFunctionNameUnderCursor()
         if func_name ==# ''
             echohl ErrorMsg
-            echo 'No test function was found under the cursor. Please add ! to command if you want to run all tests'
+            echomsg 'No test function was found under the cursor. Please add ! to command if you want to run all tests'
             echohl None
             return
         endif


### PR DESCRIPTION
I've got a script that auto-hides these kinds of messages after a few seconds, but it requires the messages to be written to the `message-history`, which only happens with `echom[sg]`, not `echo`.

I'm not sure what the policy is for this plugin for what goes where, some messages use `echo`, others use `echomsg`. I'd figure I create a PR and see if this change is acceptable.