### PR TITLE
always use terminal in nvim

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -505,7 +505,7 @@ function! rust#Test(all, options) abort
         return rust#Run(1, '--test ' . a:options)
     endif
 
-    if has('terminal')
+    if has('terminal') || has('nvim')
         let cmd = 'terminal '
     else
         let cmd = '!'


### PR DESCRIPTION
Fixes the use of terminal in nvim, which was broken since #341.