### PR TITLE
support custom terminal command

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -505,7 +505,9 @@ function! rust#Test(all, options) abort
         return rust#Run(1, '--test ' . a:options)
     endif
 
-    if has('terminal') || has('nvim')
+    if exists('g:rust_terminal_command')
+        let cmd = g:rust_terminal_command . ' '
+    elseif has('terminal') || has('nvim')
         let cmd = 'terminal '
     else
         let cmd = '!'

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -187,6 +187,12 @@ g:cargo_makeprg_params~
 	    let g:cargo_makeprg_params = 'build'
 <
 
+                                                        *g:rust_terminal_command*
+g:rust_terminal_command~
+	Set this option to change the way the terminal is invoked to run
+	tests:
+	    let g:rust_terminal_command = 'split | resize 20 | terminal'
+<
 
 Integration with Syntastic                                    *rust-syntastic*
 --------------------------


### PR DESCRIPTION
the `terminal` feature is great to have (one reason being that it supports escape codes and thus coloured test output), but it also forces a full-screen buffer when running a test.

By allowing people to configure `g:rust_terminal_command`, they can do something like this:

```vim
let g:rust_terminal_command = 'split | resize 20 | terminal'
```

And get a smaller split terminal window to show the test results:

<img width="1264" alt="Screenshot 2019-08-27 at 22 22 18" src="https://user-images.githubusercontent.com/383250/63805236-44f84f00-c919-11e9-8545-e8cbeebe1adb.png">
