### PR TITLE
`:setfiletype FALLBACK` is not available in older versions

### DIFF
--- a/ftdetect/rust.vim
+++ b/ftdetect/rust.vim
@@ -1,7 +1,10 @@
 " vint: -ProhibitAutocmdWithNoGroup
 
 autocmd BufRead,BufNewFile *.rs call s:set_rust_filetype()
-autocmd BufRead,BufNewFile Cargo.toml setf FALLBACK cfg
+
+if has('patch-8.0.613')
+    autocmd BufRead,BufNewFile Cargo.toml setf FALLBACK cfg
+endif
 
 function! s:set_rust_filetype() abort
     if &filetype !=# 'rust'


### PR DESCRIPTION
There is no workaround for this. If we would set the filetype first via `:set filetype=cfg` or `:setfiletype cfg`, more specialized plugins like [vim-toml](https://github.com/cespare/vim-toml), wouldn't be able to overwrite the filetype with `:setfiletype toml` anymore.

Now, we simply don't set a filetype at all for older Vim versions. Not great, but better than an error that keeps rust.vim from getting sourced properly.

Fixes https://github.com/rust-lang/rust.vim/issues/345

---

Alternative: We remove the entire line. If someone wants syntax highlighting for toml, [vim-toml](https://github.com/cespare/vim-toml) should be used.

p.s. Works with Vim and Nvim.
p.p.s This is the recommended approach for checking versions (in older Vim verions): `:h has-patch`.