### PR TITLE
Highlight `for` keyword contextually for `impl ... for ...` statement and `for` control statement

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -15,7 +15,12 @@ endif
 " Syntax definitions {{{1
 " Basic keywords {{{2
 syn keyword   rustConditional match if else
-syn keyword   rustRepeat for loop while
+syn keyword   rustRepeat loop while
+" `:syn match` must be used to prioritize highlighting `for` keyword.
+syn match     rustRepeat /\<for\>/
+" Highlight `for` keyword in `impl ... for ... {}` statement. This line must
+" be put after previous `syn match` line to overwrite it.
+syn match     rustKeyword /\%(\<impl\>.\+\)\@<=\<for\>/
 syn keyword   rustTypedef type nextgroup=rustIdentifier skipwhite skipempty
 syn keyword   rustStructure struct enum nextgroup=rustIdentifier skipwhite skipempty
 syn keyword   rustUnion union nextgroup=rustIdentifier skipwhite skipempty contained


### PR DESCRIPTION
Current rust.vim highlights `for` keyword as control statement without considering context.

For example,

```rust
struct X(i32);

impl Default for X {
    fn default() -> Self {
        X(42)
    }
}

fn main() {
    'test for i in 0..3 {
        for j in 0..3 {
            println!("hello");
        }
    }
}
```

`for` keyword of `impl Default for X {` line is highlighted as `rustRepeat` highlight group. This PR changes this behavior to highlight the `for` as `rustKeyword` highlight group while `for` in loop statements are still highlighted as `rustRepeat` highlhight group.

Here is a screenshot of my local small manual test:

![スクリーンショット 2019-09-02 17 02 24](https://user-images.githubusercontent.com/823277/64099116-79e62500-cda3-11e9-8cee-cf2debf7db29.png)

Implementation is a bit tricky. Since `:syn keyword` always has higher priority than `:syn match` in Vim highlighting, I used `:syn match /\<for\>/` instead for highlighting `for` control statements. Then I added another `:syn match` to highlight `for` keyword in `impl` statement. In Vim highlighting, later `match` syntax definition has higher priority (since later one overwrites previous one).