### PR TITLE
[WIP] Add command for cargo expand

### DIFF
--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -112,4 +112,58 @@ function! cargo#runtarget(args)
     endif
 endfunction
 
+function! cargo#expand(args)
+    call rust#Load()
+    call WithPath(function("s:Expand"), a:args)
+endfunction
+
+function! s:Expand(dict, args)
+    try
+        let basename = fnamemodify(a:dict.path, ':t:r')
+        let l:is_root_file = (basename ==# 'lib') || (basename ==# 'main')
+
+        let l:prefix = fnamemodify(cargo#nearestCargo(1), ':p:h:gs?/?::?')
+        let l:filter = (basename ==# 'mod') ? ':p:h:gs?/?::?' : ':p:r:gs?/?::?'
+        let l:path = fnamemodify(a:dict.path, l:filter)
+        let l:rust_path = substitute(l:path, l:prefix . '::src', '', '')
+        let item = l:is_root_file ? '' : substitute(l:rust_path, '::', '', '')
+        echo l:prefix
+
+        let output = system("cargo expand " . a:args . ' ' . item)
+        if v:shell_error
+            echohl WarningMsg
+            echo output
+            echohl None
+        else
+            new
+            silent put =output
+            1
+            d
+            setl filetype=rust
+            setl buftype=nofile
+            setl bufhidden=hide
+            setl noswapfile
+            " give the buffer a nice name
+            let suffix = 1
+            while 1
+                let bufname = basename
+                if suffix > 1 | let bufname .= ' ('.suffix.')' | endif
+                let bufname .= '.pretty.rs'
+                if bufexists(bufname)
+                    let suffix += 1
+                    continue
+                endif
+                exe 'silent noautocmd keepalt file' fnameescape(bufname)
+                break
+            endwhile
+            exe 'normal! 1G<CR>'
+            if l:is_root_file || basename ==# 'mod'
+                exe 'silent .,/Finished dev/+1delete'
+            else
+                exe 'silent .,/mod ' . basename . '/-1delete'
+            endif
+        endif
+    endtry
+endfunction
+
 " vim: set et sw=4 sts=4 ts=8:

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -104,7 +104,7 @@ function! rust#Run(bang, args)
     let b:rust_last_rustc_args = l:rustc_args
     let b:rust_last_args = l:args
 
-    call s:WithPath(function("s:Run"), rustc_args, args)
+    call WithPath(function("s:Run"), rustc_args, args)
 endfunction
 
 function! s:Run(dict, rustc_args, args)
@@ -139,7 +139,7 @@ function! rust#Expand(bang, args)
     else
         let pretty = "expanded"
     endif
-    call s:WithPath(function("s:Expand"), pretty, args)
+    call WithPath(function("s:Expand"), pretty, args)
 endfunction
 
 function! s:Expand(dict, pretty, args)
@@ -203,7 +203,7 @@ endfunction
 
 function! rust#Emit(type, args)
     let args = s:ShellTokenize(a:args)
-    call s:WithPath(function("s:Emit"), a:type, args)
+    call WithPath(function("s:Emit"), a:type, args)
 endfunction
 
 function! s:Emit(dict, type, args)
@@ -270,7 +270,7 @@ endfunction
 " {dict.path} may be a path to a file inside of {dict.tmpdir} or it may be the
 " existing path of the current buffer. If the path is inside of {dict.tmpdir}
 " then it is guaranteed to have a '.rs' extension.
-function! s:WithPath(func, ...)
+function! WithPath(func, ...)
     let buf = bufnr('')
     let saved = {}
     let dict = {}

--- a/plugin/cargo.vim
+++ b/plugin/cargo.vim
@@ -19,6 +19,7 @@ command! -nargs=* Csearch  call cargo#search(<q-args>)
 command! -nargs=* Cpublish call cargo#publish(<q-args>)
 command! -nargs=* Cinstall call cargo#install(<q-args>)
 command! -nargs=* Cruntarget call cargo#runtarget(<q-args>)
+command! -nargs=* Cexpand call cargo#expand(<q-args>)
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
### Added

* Add `cargo#expand()` function.
* Add `:Cexpand` command to `cargo.vim`.

### Changed

* Rename `s:WithPath()` utility function to `WithPath()`

---

I thought it would be nice to add support for [cargo-expand](https://github.com/dtolnay/cargo-expand) in the form of a new command which behaves similarly to `:RustExpand`. This command is capable of expanding macros from third-party crates, unlike `:RustExpand`, because it is fully backed by `cargo expand` and in turn `cargo rustc`.

I haven't written anything non-trivial in VimL before, so please excuse the rough edges. First, I made the `s:WithPath()` utility function inside `autoload/rust.vim` public, since I needed access to the file path inside `autoload/cargo.vim`. If anyone could advise on alternative solutions to this, I would greatly appreciate it.

Second, this PR does not yet supply `-p` to `cargo expand` if the file being expanded is in the `.cargo` cache. This is fine in the vast majority of cases, but it does mean that opening a source file in Vim, using RLS to navigate to a third-party definition, and calling `:Cexpand` on the buffer will execute `cargo expand path::to::mod` instead of `cargo expand -p foo path::to::mod`. I don't know whether such functionality is considered part of the MVP, but I would appreciate your thoughts on this.

Finally, running `:Cexpand` on a buffer inside a Cargo workspace containing mixed bin and lib targets will error unless `:Cexpand --lib` or `:Cexpand --bin` is provided. I think we could feasibly detect whether to expand the lib or bin target based on the open buffer's file path, but I left this out pending your review.

Please let me know if there is interest in adding this functionality to `rust.vim` so I know whether to develop it further. Thanks!