### PR TITLE
Highlight label after break and continue statements as rustLabel

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -205,6 +205,7 @@ syn region rustGenericLifetimeCandidate display start=/\%(<\|,\s*\)\@<='/ end=/[
 "rustLifetime must appear before rustCharacter, or chars will get the lifetime highlighting
 syn match     rustLifetime    display "\'\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"
 syn match     rustLabel       display "\'\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*:"
+syn match     rustLabel       display "\%(\<\%(break\|continue\)\s*\)\@<=\'\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*"
 syn match   rustCharacterInvalid   display contained /b\?'\zs[\n\r\t']\ze'/
 " The groups negated here add up to 0-255 but nothing else (they do not seem to go beyond ASCII).
 syn match   rustCharacterInvalidUnicode   display contained /b'\zs[^[:cntrl:][:graph:][:alnum:][:space:]]\ze'/


### PR DESCRIPTION
Fixes #159 

I manually confirmed this fixes #159 and does not break current syntax highlighting for lifetime parameters. Here is a screenshot:

![スクリーンショット 2019-09-19 13 15 45](https://user-images.githubusercontent.com/823277/65213143-ee2d0200-dadf-11e9-8a24-bc16e3e88a0d.png)

Only `'label`s after `break` and `continue` statements are highlighted as `rustLabel`