### PR TITLE
Highlight `in` with the same color as `for`

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -21,6 +21,7 @@ syn match     rustRepeat /\<for\>/
 " Highlight `for` keyword in `impl ... for ... {}` statement. This line must
 " be put after previous `syn match` line to overwrite it.
 syn match     rustKeyword /\%(\<impl\>.\+\)\@<=\<for\>/
+syn keyword   rustRepeat in
 syn keyword   rustTypedef type nextgroup=rustIdentifier skipwhite skipempty
 syn keyword   rustStructure struct enum nextgroup=rustIdentifier skipwhite skipempty
 syn keyword   rustUnion union nextgroup=rustIdentifier skipwhite skipempty contained
@@ -38,7 +39,7 @@ syn keyword   rustKeyword     continue
 syn keyword   rustKeyword     crate
 syn keyword   rustKeyword     extern nextgroup=rustExternCrate,rustObsoleteExternMod skipwhite skipempty
 syn keyword   rustKeyword     fn nextgroup=rustFuncName skipwhite skipempty
-syn keyword   rustKeyword     in impl let
+syn keyword   rustKeyword     impl let
 syn keyword   rustKeyword     macro
 syn keyword   rustKeyword     pub nextgroup=rustPubScope skipwhite skipempty
 syn keyword   rustKeyword     return


### PR DESCRIPTION
Current rust.vim highlights `for` with `rustRepeat` but `in` with `rustKeyword`.

As far as I checked libsyntax in rustc implementation, `in` keyword is currently used only for `for` statement. I want to highlight `in` with the same color as `for` to indicate it is a part of `for` loop statement.

Here is a screenshot before/after applying this patch.

- Before

![スクリーンショット 2019-09-20 13 00 32](https://user-images.githubusercontent.com/823277/65298642-2c412900-dba7-11e9-8d93-f2f600dccca7.png)

- After

![スクリーンショット 2019-09-20 13 00 52](https://user-images.githubusercontent.com/823277/65298656-32cfa080-dba7-11e9-974a-3a607d2dcbda.png)
