### PR TITLE
Refactoring for s:RmDir() in autoload/rust.vim

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -396,10 +396,19 @@ function! s:RmDir(path)
         echoerr 'Attempted to delete empty path'
         return 0
     elseif a:path ==# '/' || a:path ==# $HOME
-        echoerr 'Attempted to delete protected path: ' . a:path
+        let l:path = expand(a:path)
+        if l:path ==# '/' || l:path ==# $HOME
+            echoerr 'Attempted to delete protected path: ' . a:path
+            return 0
+        endif
+    endif
+
+    if !isdirectory(a:path)
         return 0
     endif
-    return system("rm -rf " . shellescape(a:path))
+
+    " delete() returns 0 when removing file successfully
+    return delete(a:path, 'rf') == 0
 endfunction
 
 " Executes {cmd} with the cwd set to {pwd}, without changing Vim's cwd.


### PR DESCRIPTION
- Check the directory exists using `isdirectory()`. If it does not exist, we don't need to remove it
- Check given path is not home and root after ensuring the path is expanded. Relative path does not match to them
- Use `delete()` built-in function rather than executing `rm` command. It works on Windows and we don't need to take care about path escaping.