### PR TITLE
Use separate buffer in Neovim

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -514,8 +514,10 @@ function! rust#Test(all, options) abort
         return rust#Run(1, '--test ' . a:options)
     endif
 
-    if has('terminal') || has('nvim')
+    if has('terminal')
         let cmd = 'terminal '
+    elseif has('nvim')
+        let cmd = 'new | terminal '
     else
         let cmd = '!'
         let manifest = shellescape(manifest)

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -517,7 +517,7 @@ function! rust#Test(all, options) abort
     if has('terminal')
         let cmd = 'terminal '
     elseif has('nvim')
-        let cmd = 'new | terminal '
+        let cmd = 'noautocmd new | terminal '
     else
         let cmd = '!'
         let manifest = shellescape(manifest)


### PR DESCRIPTION
While the behavior of 'terminal' in Vim and Neovim is different, all Neovim users cannot get back to the original buffer if the terminal command has directly applied.
To solve the issue and make the behavior consistent, execute 'new' prior to 'terminal' in Neovim.

## Without this PR
https://asciinema.org/a/42wz3Z9LuKlylLTeZkk7rhuUU

## With this PR
https://asciinema.org/a/BFkMEcdYCKn3EnWwDXixcckoB