### PR TITLE
RustTest: take optional command modifiers and window size

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -508,16 +508,16 @@ function! s:SearchTestFunctionNameUnderCursor() abort
     return matchstr(getline(test_func_line), '\m\C^\s*fn\s\+\zs\h\w*')
 endfunction
 
-function! rust#Test(all, options) abort
+function! rust#Test(mods, all, options) abort
     let manifest = findfile('Cargo.toml', expand('%:p:h') . ';')
     if manifest ==# ''
         return rust#Run(1, '--test ' . a:options)
     endif
 
     if has('terminal')
-        let cmd = 'terminal '
+        let cmd = printf('%s terminal ', a:mods)
     elseif has('nvim')
-        let cmd = 'noautocmd new | terminal '
+        let cmd = printf('%s noautocmd new | terminal ', a:mods)
     else
         let cmd = '!'
         let manifest = shellescape(manifest)

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -508,20 +508,23 @@ function! s:SearchTestFunctionNameUnderCursor() abort
     return matchstr(getline(test_func_line), '\m\C^\s*fn\s\+\zs\h\w*')
 endfunction
 
-function! rust#Test(mods, all, options) abort
+function! rust#Test(mods, winsize, all, options) abort
     let manifest = findfile('Cargo.toml', expand('%:p:h') . ';')
     if manifest ==# ''
         return rust#Run(1, '--test ' . a:options)
     endif
 
+    " <count> defaults to 0, but we prefer an empty string
+    let winsize = a:winsize ? a:winsize : ''
+
     if has('terminal')
         if has('patch-8.0.910')
-            let cmd = printf('%s noautocmd new | terminal ++curwin ', a:mods)
+            let cmd = printf('%s noautocmd %snew | terminal ++curwin ', a:mods, winsize)
         else
             let cmd = printf('%s terminal ', a:mods)
         endif
     elseif has('nvim')
-        let cmd = printf('%s noautocmd new | terminal ', a:mods)
+        let cmd = printf('%s noautocmd %snew | terminal ', a:mods, winsize)
     else
         let cmd = '!'
         let manifest = shellescape(manifest)

--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -515,7 +515,11 @@ function! rust#Test(mods, all, options) abort
     endif
 
     if has('terminal')
-        let cmd = printf('%s terminal ', a:mods)
+        if has('patch-8.0.910')
+            let cmd = printf('%s noautocmd new | terminal ++curwin ', a:mods)
+        else
+            let cmd = printf('%s terminal ', a:mods)
+        endif
     elseif has('nvim')
         let cmd = printf('%s noautocmd new | terminal ', a:mods)
     else

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -426,11 +426,14 @@ functionality from other plugins.
 Running test(s)
 ---------------
 
-:RustTest[!] [options]                                          *:RustTest*
+:[N]RustTest[!] [options]                                       *:RustTest*
 		Runs a test under the cursor when the current buffer is in a
 		cargo project with "cargo test" command. If the command did
 		not find any test function under the cursor, it stops with an
 		error message.
+
+		When N is given, adjust the size of the new window to N lines
+		or columns.
 
 		When ! is given, runs all tests regardless of current cursor
 		position.
@@ -444,7 +447,11 @@ Running test(s)
 		is no way to run specific test function with rustc. [options]
 		is passed to "rustc" command arguments in the case.
 
-
+		Takes optional modifiers (see |<mods>|):  >
+		    :tab RustTest
+		    :belowright 16RustTest
+		    :leftabove vert 80RustTest
+<
 rust.vim Debugging
 ------------------
 

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -137,7 +137,7 @@ command! -bar RustInfoToClipboard call rust#debugging#InfoToClipboard()
 command! -bar -nargs=1 RustInfoToFile call rust#debugging#InfoToFile(<f-args>)
 
 " See |:RustTest| for docs
-command! -buffer -nargs=* -bang RustTest call rust#Test(<bang>0, <q-args>)
+command! -buffer -nargs=* -bang RustTest call rust#Test(<q-mods>, <bang>0, <q-args>)
 
 if !exists("b:rust_last_rustc_args") || !exists("b:rust_last_args")
     let b:rust_last_rustc_args = []

--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -137,7 +137,7 @@ command! -bar RustInfoToClipboard call rust#debugging#InfoToClipboard()
 command! -bar -nargs=1 RustInfoToFile call rust#debugging#InfoToFile(<f-args>)
 
 " See |:RustTest| for docs
-command! -buffer -nargs=* -bang RustTest call rust#Test(<q-mods>, <bang>0, <q-args>)
+command! -buffer -nargs=* -count -bang RustTest call rust#Test(<q-mods>, <count>, <bang>0, <q-args>)
 
 if !exists("b:rust_last_rustc_args") || !exists("b:rust_last_args")
     let b:rust_last_rustc_args = []


### PR DESCRIPTION
This makes it very easy to customize the terminal window size and position.

Examples:

| Command | Description |
|-|-|
| `:tab RustTest` | Open terminal in new tab. |
| `:leftabove 20RustTest` | Open terminal window at the top. Window height is 20 lines. |
| `:rightbelow vert 80RustTest` | Open terminal window at the right side. Window width is 80 columns. |

See `:h <mods>` for all supported command modifiers.

If this PR gets merged, [this one](https://github.com/rust-lang/rust.vim/pull/344) can be closed.