### PR TITLE
Use :terminal for running cargo

### DIFF
--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -3,7 +3,17 @@ function! cargo#Load()
 endfunction
 
 function! cargo#cmd(args)
-    execute "! cargo" a:args
+    " Trim trailing spaces. This is necessary since :terminal command parses
+    " trailing spaces as an empty argument.
+    let args = substitute(a:args, '\s\+$', '', '')
+    if has('terminal')
+        let cmd = 'terminal'
+    elseif has('nvim')
+        let cmd = 'noautocmd new | terminal'
+    else
+        let cmd = '!'
+    endif
+    execute cmd 'cargo' args
 endfunction
 
 function! s:nearest_cargo(...) abort


### PR DESCRIPTION
`:RustTest` uses terminal feature but cargo commands don't. This PR makes cargo commands such as `Cbuild`, `Ctest`, ... use `:terminal` to run `cargo` command.

![tmp](https://user-images.githubusercontent.com/823277/67637552-fb2ee380-f91e-11e9-9fdc-016b9903dd0f.gif)
