### PR TITLE
Update doc comment syntax.

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -321,11 +321,11 @@ hi def link rustFuncName      Function
 hi def link rustFuncCall      Function
 hi def link rustShebang       Comment
 hi def link rustCommentLine   Comment
-hi def link rustCommentLineDoc SpecialComment
+hi def link rustCommentLineDoc Comment
 hi def link rustCommentLineDocLeader rustCommentLineDoc
 hi def link rustCommentLineDocError Error
 hi def link rustCommentBlock  rustCommentLine
-hi def link rustCommentBlockDoc rustCommentLineDoc
+hi def link rustCommentBlockDoc SpecialComment
 hi def link rustCommentBlockDocStar rustCommentBlockDoc
 hi def link rustCommentBlockDocError Error
 hi def link rustCommentDocCodeFence rustCommentLineDoc


### PR DESCRIPTION
This change makes them like regular comments and make doc blocks use the
SpecialComment hilighting group.