### PR TITLE
Highlight the unit type

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -190,6 +190,9 @@ syn match     rustFloat       display "\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)\%([eE][
 syn match     rustFloat       display "\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)\=\%([eE][+-]\=[0-9_]\+\)\(f32\|f64\)\="
 syn match     rustFloat       display "\<[0-9][0-9_]*\%(\.[0-9][0-9_]*\)\=\%([eE][+-]\=[0-9_]\+\)\=\(f32\|f64\)"
 
+" The unit type, an empty tuple
+syn match     rustUnit        '\(\s\|<\|=\|, *\|(\)\@<=()'
+
 " For the benefit of delimitMate
 syn region rustLifetimeCandidate display start=/&'\%(\([^'\\]\|\\\(['nrt0\\\"]\|x\x\{2}\|u{\%(\x_*\)\{1,6}}\)\)'\)\@!/ end=/[[:cntrl:][:space:][:punct:]]\@=\|$/ contains=rustSigil,rustLifetime
 syn region rustGenericRegion display start=/<\%('\|[^[:cntrl:][:space:][:punct:]]\)\@=')\S\@=/ end=/>/ contains=rustGenericLifetimeCandidate
@@ -297,6 +300,7 @@ hi def link rustEnumVariant   rustConstant
 hi def link rustConstant      Constant
 hi def link rustSelf          Constant
 hi def link rustFloat         Float
+hi def link rustUnit          Constant
 hi def link rustArrowCharacter rustOperator
 hi def link rustOperator      Operator
 hi def link rustKeyword       Keyword


### PR DESCRIPTION
Inspired by [the recent post in r/rust](https://www.reddit.com/r/rust/comments/dwa1jm/unit_highlighting_in_emacs/), I have added unit type highlighting. The regex was definitely quick and dirty, but it seems to work for me in most cases.