### PR TITLE
use poor man's shellescape in case %:S unavailable

### DIFF
--- a/compiler/rustc.vim
+++ b/compiler/rustc.vim
@@ -24,7 +24,7 @@ else
     if has('patch-7.4.191')
       CompilerSet makeprg=rustc\ \%:S
     else
-      CompilerSet makeprg=rustc\ \%
+      CompilerSet makeprg=rustc\ \"%\"
     endif
 endif
 


### PR DESCRIPTION
Might be worth a try. Found this, e.g., in `$VIMRUNTIME/compiler/jikes.vim`.