### PR TITLE
Add g:cargo_shell_command_runner to specify how to run cargo commands

### DIFF
--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -1,12 +1,14 @@
-function! cargo#Load() 
+function! cargo#Load()
     " Utility call to get this script loaded, for debugging
 endfunction
 
-function! cargo#cmd(args)
+function! cargo#cmd(args) abort
     " Trim trailing spaces. This is necessary since :terminal command parses
     " trailing spaces as an empty argument.
     let args = substitute(a:args, '\s\+$', '', '')
-    if has('terminal')
+    if exists('g:cargo_shell_command_runner')
+        let cmd = g:cargo_shell_command_runner
+    elseif has('terminal')
         let cmd = 'terminal'
     elseif has('nvim')
         let cmd = 'noautocmd new | terminal'

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -187,6 +187,16 @@ g:cargo_makeprg_params~
 	    let g:cargo_makeprg_params = 'build'
 <
 
+                                                  *g:cargo_shell_command_runner*
+g:cargo_shell_command_runner~
+	Set this option to change how to run shell commands for cargo commands
+	|:Cargo|, |:Cbuild|, |:Crun|, ...
+	By default, |:terminal| is used to run shell command in terminal window
+	asynchronously. But if you prefer |:!| for running the commands, it can
+	be specified: >
+	    let g:cargo_shell_command_runner = '!'
+<
+
 
 Integration with Syntastic                                    *rust-syntastic*
 --------------------------


### PR DESCRIPTION
Fixes #376

This PR adds `g:cargo_shell_command_runner` to customize how to run shell commands for cargo.

For example, by setting `"!"` to it, `:!` command is used to run `cargo ...` commands on `:Cargo`, `:Cbuild`, `:Crun`, ...

```vim
let g:cargo_shell_command_runner = '!'
```