### PR TITLE
Allow bar to be placed after :RustFmt

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -121,7 +121,7 @@ command! -nargs=* -buffer RustEmitAsm call rust#Emit("asm", <q-args>)
 command! -range=% RustPlay :call rust#Play(<count>, <line1>, <line2>, <f-args>)
 
 " See |:RustFmt| for docs
-command! -buffer RustFmt call rustfmt#Format()
+command! -bar -buffer RustFmt call rustfmt#Format()
 
 " See |:RustFmtRange| for docs
 command! -range -buffer RustFmtRange call rustfmt#FormatRange(<line1>, <line2>)


### PR DESCRIPTION
This PR allows constructs such as:

```vim
autocmd BufWritePre <buffer> if &modified | RustFmt | endif
```

Which currently fail with `E488`.

The "feature" is added by specifiying `-bar` when defining `RustFmt`