### PR TITLE
Implement the remaining cargo# functions

### DIFF
--- a/autoload/cargo.vim
+++ b/autoload/cargo.vim
@@ -100,6 +100,22 @@ function! cargo#bench(args)
     call cargo#cmd("bench " . a:args)
 endfunction
 
+function! cargo#update(args)
+    call cargo#cmd("update " . a:args)
+endfunction
+
+function! cargo#search(args)
+    call cargo#cmd("search " . a:args)
+endfunction
+
+function! cargo#publish(args)
+    call cargo#cmd("publish " . a:args)
+endfunction
+
+function! cargo#install(args)
+    call cargo#cmd("install " . a:args)
+endfunction
+
 function! cargo#runtarget(args)
     let l:filename = expand('%:p')
     let l:read_manifest = system('cargo read-manifest')


### PR DESCRIPTION
Follow-up to #129 - the `:Cupdate`, `:Csearch`, `:Cpublish` and `:Cinstall` commands try to call the functions `cargo#update`, `cargo#search`, etc., but the original PR did not implement these, so you just get an error if you try.