### PR TITLE
Update Readme to correctly load the `RustFmt` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ configure Tagbar to some degree.
 ### Formatting with [rustfmt][rfmt]
 
 The `:RustFmt` command will format your code with
-[rustfmt][rfmt] if installed.
+[rustfmt][rfmt] if installed and if you have `filetype plugin on`
+in your `.vimrc`.
 
 Placing `let g:rustfmt_autosave = 1` in your `~/.vimrc` will
 enable automatic running of `:RustFmt` when you save a buffer.


### PR DESCRIPTION
When using vim8 installation method, `RustFmt` isn't a valid command.
After some researches, I found
https://github.com/rust-lang/rust.vim/issues/262 which suggested to add
`filetype indent on` in my .vimrc witch solved the issue.

Note: I'm not sure if this should be added in the `RustFmt` section or the
`vim8` section.