### PR TITLE
Fix highlighting raw identifier

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -65,11 +65,12 @@ syn match   rustExternCrateString /".*"\_s*as/ contained nextgroup=rustIdentifie
 syn keyword   rustObsoleteExternMod mod contained nextgroup=rustIdentifier skipwhite skipempty
 
 syn match     rustIdentifier  contains=rustIdentifierPrime "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
-syn match     rustFuncName    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
+syn match     rustFuncName    "\%(r#\)\=\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 
 syn region rustMacroRepeat matchgroup=rustMacroRepeatDelimiters start="$(" end=")" contains=TOP nextgroup=rustMacroRepeatCount
 syn match rustMacroRepeatCount ".\?[*+]" contained
 syn match rustMacroVariable "$\w\+"
+syn match rustRawIdent "\<r#\h\w*" contains=NONE
 
 " Reserved (but not yet used) keywords {{{2
 syn keyword   rustReservedKeyword become do priv typeof unsized abstract virtual final override


### PR DESCRIPTION
I noticed that [raw identifiers](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/raw-identifiers.html) are not highlighted correctly.

<img width="404" alt="スクリーンショット 2020-02-27 1 46 59" src="https://user-images.githubusercontent.com/823277/75367254-63a8c400-5903-11ea-8083-ca04ce6c3dbd.png">

Note: `r` in `fn r#match` is highlighted as `rustFuncName` but `#match` is highlighted as `rustMacroName`. They happen to have the same color.

This PR fixes the highlight as follows:

<img width="425" alt="スクリーンショット 2020-02-27 1 47 38" src="https://user-images.githubusercontent.com/823277/75367308-74593a00-5903-11ea-8f73-74612a13dec4.png">
