### PR TITLE
Prefer matchit.vim to % at :RustTest if available

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -499,7 +499,15 @@ function! s:SearchTestFunctionNameUnderCursor() abort
 
     " Search the end of test function (closing brace) to ensure that the
     " cursor position is within function definition
-    normal! %
+    if maparg('<Plug>(MatchitNormalForward)') ==# ''
+        normal! %
+    else
+        " Prefer matchit.vim official plugin to native % since the plugin
+        " provides better behavior than original % (#391)
+        " To load the plugin, run:
+        "   :packadd matchit
+        execute 'normal' "\<Plug>(MatchitNormalForward)"
+    endif
     if line('.') < cursor_line
         return ''
     endif


### PR DESCRIPTION
Fixes #391 

As I described in #391, Vim's native `%` cannot find proper pair of `{` and `}` in some situation. However, rust.vim supports official matchit.vim plugin which extends `%` and solve the issue. I confirmed `%` works fine after `:packadd matchit`.

This patch will use matchit.vim to find the end of target test function if user already loaded matchit.vim. Otherwise, it fall backs into native `%`.

I confirmed this patch fixed #391 after loading matchit.vim with `:packadd matchit`