### PR TITLE
Fix restoring cursor position on :RustTest

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -541,21 +541,20 @@ function! rust#Test(mods, winsize, all, options) abort
     let saved = getpos('.')
     try
         let func_name = s:SearchTestFunctionNameUnderCursor()
-        if func_name ==# ''
-            echohl ErrorMsg
-            echomsg 'No test function was found under the cursor. Please add ! to command if you want to run all tests'
-            echohl None
-            return
-        endif
-        if a:options ==# ''
-            execute cmd . 'cargo test --manifest-path' manifest func_name
-        else
-            execute cmd . 'cargo test --manifest-path' manifest func_name a:options
-        endif
-        return
     finally
         call setpos('.', saved)
     endtry
+    if func_name ==# ''
+        echohl ErrorMsg
+        echomsg 'No test function was found under the cursor. Please add ! to command if you want to run all tests'
+        echohl None
+        return
+    endif
+    if a:options ==# ''
+        execute cmd . 'cargo test --manifest-path' manifest func_name
+    else
+        execute cmd . 'cargo test --manifest-path' manifest func_name a:options
+    endif
 endfunction
 
 " }}}1


### PR DESCRIPTION
`rust#Test()` tries to restore cursor position by `setpos()`, but it is not working.

`:RustTest` runs `cargo test` command in terminal window. So, the `setpos()` is called in the terminal window. To restore cursor position correctly, we need to restore cursor position before opening terminal window. This PR fixes the point.