### PR TITLE
Fix highlighting macro repeat $()* and $()+

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -67,8 +67,7 @@ syn keyword   rustObsoleteExternMod mod contained nextgroup=rustIdentifier skipw
 syn match     rustIdentifier  contains=rustIdentifierPrime "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 syn match     rustFuncName    "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 
-syn region rustMacroRepeat matchgroup=rustMacroRepeatDelimiters start="$(" end=")" contains=TOP nextgroup=rustMacroRepeatCount
-syn match rustMacroRepeatCount ".\?[*+]" contained
+syn region rustMacroRepeat matchgroup=rustMacroRepeatDelimiters start="$(" end="),\=[*+]" contains=TOP
 syn match rustMacroVariable "$\w\+"
 
 " Reserved (but not yet used) keywords {{{2
@@ -278,7 +277,6 @@ hi def link rustIdentifierPrime rustIdentifier
 hi def link rustTrait           rustType
 hi def link rustDeriveTrait     rustTrait
 
-hi def link rustMacroRepeatCount   rustMacroRepeatDelimiters
 hi def link rustMacroRepeatDelimiters   Macro
 hi def link rustMacroVariable Define
 hi def link rustSigil         StorageClass


### PR DESCRIPTION
I found that syntax highlight is broken when macro repeats `$(...)*` and `$(...)+` are containing `)`.

```rust
macro_rules! twice {
    ($($name:ident)+) => {
        $(
            $name();
            $name();
        )+
    };
}
```

<img width="226" alt="スクリーンショット 2020-03-15 9 48 53" src="https://user-images.githubusercontent.com/823277/76693030-3483a800-66a2-11ea-86d0-fce41dcb17c8.png">


This patch fixes it as follows:

<img width="227" alt="スクリーンショット 2020-03-15 9 48 19" src="https://user-images.githubusercontent.com/823277/76693023-1e75e780-66a2-11ea-8269-a29cb915d33b.png">
