### PR TITLE
Add configurable g:rust_cargo_check_cmd for syntax checking

### DIFF
--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -213,6 +213,14 @@ days, 'cargo' is the default checker. >
 <
 If you would like to change it, you can set `g:syntastic_rust_checkers` to a
 different value.
+						      *g:rust_cargo_check_cmd*
+						      *b:rust_cargo_check_cmd*
+g:rust_cargo_check_cmd~
+	Cargo will check files with this command. For embedded applications,
+	where sysroot may change, this can be used (e.g. with cargo-xbuild) to
+	invoke a different cargo command when checking files.
+	The default is 'check'.
+
                                           *g:rust_cargo_avoid_whole_workspace*
                                           *b:rust_cargo_avoid_whole_workspace*
 g:rust_cargo_avoid_whole_workspace~

--- a/syntax_checkers/rust/cargo.vim
+++ b/syntax_checkers/rust/cargo.vim
@@ -14,6 +14,10 @@ let g:loaded_syntastic_rust_cargo_checker = 1
 " Force syntastic to call cargo without a specific file name
 let g:syntastic_rust_cargo_fname = ""
 
+if !exists("g:rust_cargo_check_cmd")
+    let g:rust_cargo_check_cmd = "check"
+endif
+
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -28,7 +32,7 @@ function! SyntaxCheckers_rust_cargo_IsAvailable() dict
 endfunction
 
 function! SyntaxCheckers_rust_cargo_GetLocList() dict
-    let makeprg = self.makeprgBuild({ "args": "check" })
+    let makeprg = self.makeprgBuild({ "args": g:rust_cargo_check_cmd })
     let l:root_cargo_toml = cargo#nearestRootCargo(0)
     let l:nearest_cargo_toml = cargo#nearestCargo(0)
     let b:rust_recent_root_cargo_toml = l:root_cargo_toml


### PR DESCRIPTION
Adds configuration to change the cargo command used for syntax checking.
Without this, using a custom toolchain will fail to find the core crate.