### PR TITLE
Syntax for asm! macro (RFC 2850)

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -230,6 +230,27 @@ syn region rustCommentBlockDocNestError matchgroup=rustCommentBlockDocError star
 
 syn keyword rustTodo contained TODO FIXME XXX NB NOTE
 
+" asm! macro {{{2
+syn region rustAsmMacro matchgroup=rustMacro start="\<asm!\s*(" end=")" contains=rustAsmDirSpec,rustAsmSym,rustAsmConst,rustAsmOptionsGroup,rustComment.*,rustString.*
+
+" Clobbered registers
+syn keyword rustAsmDirSpec in out lateout inout inlateout contained nextgroup=rustAsmReg skipwhite skipempty
+syn region  rustAsmReg start="(" end=")" contained contains=rustString
+
+" Symbol operands
+syn keyword rustAsmSym sym contained nextgroup=rustAsmSymPath skipwhite skipempty
+syn region  rustAsmSymPath start="\S" end=",\|)"me=s-1 contained contains=rustComment.*,rustIdentifier
+
+" Const
+syn region  rustAsmConstBalancedParens start="("ms=s+1 end=")" contained contains=@rustAsmConstExpr
+syn cluster rustAsmConstExpr contains=rustComment.*,rust.*Number,rustString,rustAsmConstBalancedParens
+syn region  rustAsmConst start="const" end=",\|)"me=s-1 contained contains=rustStorage,@rustAsmConstExpr
+
+" Options
+syn region  rustAsmOptionsGroup start="options\s*(" end=")" contained contains=rustAsmOptions,rustAsmOptionsKey
+syn keyword rustAsmOptionsKey options contained
+syn keyword rustAsmOptions pure nomem readonly preserves_flags noreturn nostack att_syntax contained
+
 " Folding rules {{{2
 " Trivial folding rules to begin with.
 " FIXME: use the AST to make really good folding
@@ -345,6 +366,10 @@ hi def link rustObsoleteExternMod Error
 hi def link rustQuestionMark  Special
 hi def link rustAsync         rustKeyword
 hi def link rustAwait         rustKeyword
+hi def link rustAsmDirSpec    rustKeyword
+hi def link rustAsmSym        rustKeyword
+hi def link rustAsmOptions    rustKeyword
+hi def link rustAsmOptionsKey rustAttribute
 
 " Other Suggestions:
 " hi rustAttribute ctermfg=cyan


### PR DESCRIPTION
This patch adds support for the syntax added in https://github.com/rust-lang/rust/pull/69171 for the `asm!` macro.

As an example, these screenshots show the difference in the highlight of the macro.

* [Current master](https://user-images.githubusercontent.com/37484/84216921-58e0fc00-aaba-11ea-9f60-adcd813751a7.png)
* [After these changes](https://user-images.githubusercontent.com/37484/84216918-57173880-aaba-11ea-914f-00a2504b10dc.png)
