### PR TITLE
Use winsaveview()/winrestview() instead of :mkview/:loadview for restoring the window view

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -107,7 +107,7 @@ function! s:DeleteLines(start, end) abort
 endfunction
 
 function! s:RunRustfmt(command, tmpname, from_writepre)
-    mkview!
+    let l:view = winsaveview()
 
     let l:stderr_tmpname = tempname()
     call writefile([], l:stderr_tmpname)
@@ -213,7 +213,7 @@ function! s:RunRustfmt(command, tmpname, from_writepre)
         lwindow
     endif
 
-    silent! loadview
+    call winrestview(l:view)
 endfunction
 
 function! rustfmt#FormatRange(line1, line2)


### PR DESCRIPTION
The current implementation fails to restore the cursor position when

- it fails to store the view due to incorrectly configured 'viewdir'
- 'viewoptions' does not include 'cursor'

Using winsaveview()/winrestview() can restore the view with no side-effect.