### PR TITLE
Adds support to :RustTest command for non standard test libraries

### DIFF
--- a/autoload/rust.vim
+++ b/autoload/rust.vim
@@ -486,8 +486,8 @@ endfunction
 function! s:SearchTestFunctionNameUnderCursor() abort
     let cursor_line = line('.')
 
-    " Find #[test] attribute
-    if search('\m\C#\[test\]', 'bcW') is 0
+    " Find any #[.*test] attribute (e.g. [tokio::test])
+    if search('\m\C#\[.*test\]', 'bcW') is 0
         return ''
     endif
 


### PR DESCRIPTION
The current implementation of `SearchTestFunctionNameUnderCursor` does not detect `[tokio::test]` as being a valid test attribute, this change adds a wildcard to the start of the test detection regexp.