### PR TITLE
remove tabstop setting

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -47,7 +47,7 @@ setlocal smartindent nocindent
 
 if get(g:, 'rust_recommended_style', 1)
     let b:rust_set_style = 1
-    setlocal tabstop=8 shiftwidth=4 softtabstop=4 expandtab
+    setlocal shiftwidth=4 softtabstop=4 expandtab
     setlocal textwidth=99
 endif
 


### PR DESCRIPTION
Rust code should not have tabstops, so there is no reason to configure their apperance.
If the code does have tabstops the user should see the tabs as configured in vimrc.
There are some reasons why it should not be 4: 46bfb18bbced
closes #393