### PR TITLE
Fix indentation for closing parentheses

### DIFF
--- a/indent/rust.vim
+++ b/indent/rust.vim
@@ -272,6 +272,31 @@ function GetRustIndent(lnum)
         endif
     endif
 
+    " cindent messes up indentation of closing parentheses. It does so
+    " regardless of the cindent options.
+    "
+    " Consider this input example, where | is the cursor:
+    "
+    "     foo(|)
+    "
+    " When pressing Enter, the indentation will be this:
+    "
+    "     foo(
+    "         |)
+    "
+    " But that's not what we want, we want it to be this instead:
+    "
+    "     foo(
+    "     |)
+    if line =~# '\V\^\s\*)'
+        let l:paren_start = searchpair('(', '', ')', 'nbW',
+            \ 's:is_string_comment(line("."), col("."))')
+
+        if l:paren_start != 0 && l:paren_start < a:lnum
+            return indent(l:paren_start)
+        endif
+    endif
+
     " Fall back on cindent, which does it mostly right
     return cindent(a:lnum)
 endfunction


### PR DESCRIPTION
To help explain this problem, consider this input (where | is the
cursor):

    foo(|)

Prior to this commit, pressing Enter would result in the following:

    foo(
        |)

That is, the closing parenthesis is indented by one level. This is the
case regardless of the cindent options/keys chosen.

To fix this, we manually indent lines that start with a ")" (ignoring
leading whitespace). Such lines are indented according to the
indentation of the line that contained the opening parenthesis.

Fixes #443