### PR TITLE
Ignore non-error compiler output

### DIFF
--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -34,6 +34,7 @@ augroup END
 " Ignore general cargo progress messages
 CompilerSet errorformat+=
             \%-G%\\s%#Downloading%.%#,
+            \%-G%\\s%#Checking%.%#,
             \%-G%\\s%#Compiling%.%#,
             \%-G%\\s%#Finished%.%#,
             \%-G%\\s%#error:\ Could\ not\ compile\ %.%#,

--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -39,6 +39,7 @@ CompilerSet errorformat+=
             \%-G%\\s%#Finished%.%#,
             \%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
             \%-G%\\s%#To\ learn\ more\\,%.%#,
+            \%-G%\\s%#For\ more\ information\ about\ this\ error\\,%.%#,
             \%-Gnote:\ Run\ with\ \`RUST_BACKTRACE=%.%#,
             \%.%#panicked\ at\ \\'%m\\'\\,\ %f:%l:%c
 


### PR DESCRIPTION
Remove "Checking" and "For more information about this error" messages from `cargo check` from the quickfix buffer.

When one of these lines are present, commands that navigate to the next item in the quickfix buffer will land on them.

Also, this worked for me, but I don't know a ton about errorformat strings, so someone who does should probably scrutinize this.