### PR TITLE
Add cargo commands to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ NeoBundle 'rust-lang/rust.vim'
 ## Features
 
 * `:Cargo`
-* `:Cbuild:` Compile the current package
-* `:Ccheck:` Analyze the current package and report errors, but don't build object files
-* `:Cclean:` Remove the target directory
-* `:Cdoc:` Build this package's and its dependencies' documentation
+* `:Cbuild` Compile the current package
+* `:Ccheck` Analyze the current package and report errors, but don't build object files
+* `:Cclean` Remove the target directory
+* `:Cdoc` Build this package's and its dependencies' documentation
 * `:Cnew` Create a new cargo package
 * `:Cinit` Create a new cargo package in an existing directory
 * `:Crun`  Run a binary or example of the local package

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ NeoBundle 'rust-lang/rust.vim'
 
 ## Features
 
+### Manage packages with [Cargo][cargo]
 * `:Cargo`
 * `:Cbuild` Compile the current package
 * `:Ccheck` Analyze the current package and report errors, but don't build object files
@@ -143,6 +144,7 @@ LICENSE-MIT for details.
 [vp]: https://github.com/junegunn/vim-plug
 [d]: https://github.com/Shougo/dein.vim
 [rfmt]: https://github.com/rust-lang-nursery/rustfmt
+[cargo]: https://doc.rust-lang.org/cargo/commands/cargo.html
 [syn]: https://github.com/scrooloose/syntastic
 [tgbr]: https://github.com/majutsushi/tagbar
 [uctags]: https://ctags.io

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ NeoBundle 'rust-lang/rust.vim'
 
 ## Features
 
+* `:Cargo`
+* `:Cbuild:` Compile the current package
+* `:Ccheck:` Analyze the current package and report errors, but don't build object files
+* `:Cclean:` Remove the target directory
+* `:Cdoc:` Build this package's and its dependencies' documentation
+* `:Cnew` Create a new cargo package
+* `:Cinit` Create a new cargo package in an existing directory
+* `:Crun`  Run a binary or example of the local package
+* `:Ctest` Run the tests
+* `:Cbench` Run the benchmarks
+* `:Cupdate` Update dependencies listed in Cargo.lock
+* `:Csearch` Search registry for crates
+* `:Cpublish` Package and upload this package to the registry
+* `:Cinstall` Install a Rust binary. Default location is $HOME/.cargo/bin
+* `:Cruntarget` Run with specified target
+
 ### Error checking with [Syntastic][syn]
 
 `rust.vim` automatically registers `cargo` as a syntax checker with


### PR DESCRIPTION
I feel that the list of cargo commands is useful to have in the readme.