### PR TITLE
Fix indentation after an array literal

### DIFF
--- a/indent/rust.vim
+++ b/indent/rust.vim
@@ -235,6 +235,12 @@ function GetRustIndent(lnum)
         return indent(prevlinenum)
     endif
 
+    " if the previous line ends with '];' then it is the end of an array literal. The current line
+    " should start from the same position as the previous one.
+    if prevline[len(prevline) - 2:] ==# "];"
+        return indent(prevlinenum)
+    endif
+
     if !has("patch-7.4.355")
         " cindent before 7.4.355 doesn't do the module scope well at all; e.g.::
         "


### PR DESCRIPTION
Let's consider this case
```
fn walk() {
    let positions = [
        [0.0, 0.0, 0.0],
        [2.0, 5.0, -15.0],
        [-1.5, -2.2, -2.5],
        [-3.8, -2.0, -12.3],
    ];

        let speed = 123;
}
```
As you might see `let speed = 123` stays in the wrong position because it's treated by `cindent` called in the end of the function. The patch makes it this way

```
fn walk() {
    let positions = [
        [0.0, 0.0, 0.0],
        [2.0, 5.0, -15.0],
        [-1.5, -2.2, -2.5],
        [-3.8, -2.0, -12.3],
    ];

    let speed = 123;
}
```