### PR TITLE
Fix `$(...)?` highlighting

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -67,7 +67,7 @@ syn keyword   rustObsoleteExternMod mod contained nextgroup=rustIdentifier skipw
 syn match     rustIdentifier  contains=rustIdentifierPrime "\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 syn match     rustFuncName    "\%(r#\)\=\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*" display contained
 
-syn region rustMacroRepeat matchgroup=rustMacroRepeatDelimiters start="$(" end="),\=[*+]" contains=TOP
+syn region rustMacroRepeat matchgroup=rustMacroRepeatDelimiters start="$(" end=")\%(,\=[*+]\|?\)" contains=TOP
 syn match rustMacroVariable "$\w\+"
 syn match rustRawIdent "\<r#\h\w*" contains=NONE
 


### PR DESCRIPTION
`$(...)?` is a macro repeat operator (0 or 1) like `$(...)*` (0 or more) or `$(...)+` (1 or more). `+` and `*` are correctly highlighted, but `?` is not highlighted. This PR adds highlight for `$(...)?`. `*` and `+` allows delimiter like `$(...),*`, but `?` doesn't.

Before:

<img width="564" alt="before" src="https://user-images.githubusercontent.com/823277/174304896-4e2d9c74-3a27-4c70-adfc-c7e17fe06687.png">

After:

<img width="559" alt="after" src="https://user-images.githubusercontent.com/823277/174305013-31bb15ab-d41e-4a98-95c4-4b4baac1b01b.png">