### PR TITLE
Skip child modules when running RustFmtRange

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -89,7 +89,7 @@ function! s:RustfmtCommandRange(filename, line1, line2)
     " accordingly.
     let l:unstable_features = s:rustfmt_unstable_features ? '--unstable-features' : ''
 
-    let l:cmd = printf("%s %s %s %s %s --file-lines '[%s]' %s", g:rustfmt_command,
+    let l:cmd = printf("%s %s %s %s %s --skip-children --file-lines '[%s]' %s", g:rustfmt_command,
                 \ l:write_mode, g:rustfmt_options,
                 \ l:unstable_features, l:rustfmt_config,
                 \ json_encode(l:arg), shellescape(a:filename))


### PR DESCRIPTION
The `RustFmtRange` command should not attempt to reformat any child modules of the module currently being formatted.

Without this change, I get the following error when attempting to format a range:
```
rust.vim: was not able to parse rustfmt messages. Here is the raw output:

Error writing files: failed to resolve mod `foo`: /private/var/folders/lx/810r91ls7nz_mf24vhv_94w40000gp/T/vWfCEK6/dy
foo.rs does not exist
Error detected while processing function rustfmt#FormatRange[4]..<SNR>92_RunRustfmt:
line  104:
E776: No location list
```

While `--skip-children` is unstable, the `--file-lines` option itself is also unstable, so this seems like it shouldn't be an issue.