### PR TITLE
Better errorformat

### DIFF
--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -32,14 +32,14 @@ augroup RustCargoQuickFixHooks
 augroup END
 
 " Ignore general cargo progress messages
-CompilerSet errorformat+=
+CompilerSet errorformat^=
             \%-G%\\s%#Downloading%.%#,
             \%-G%\\s%#Compiling%.%#,
             \%-G%\\s%#Finished%.%#,
             \%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
             \%-G%\\s%#To\ learn\ more\\,%.%#,
+            \%-Gerror:\ test\ failed\\,\ to\ rerun\ pass%.%#,
             \%-Gnote:\ Run\ with\ \`RUST_BACKTRACE=%.%#,
-            \%-Gnote:\ run\ with\ \`RUST_BACKTRACE=%.%#,
             \%.%#panicked\ at\ \\'%m\\'\\,\ %f:%l:%c
 
 " vint: -ProhibitAbbreviationOption

--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -34,10 +34,12 @@ augroup END
 " Ignore general cargo progress messages
 CompilerSet errorformat^=
             \%-G%\\s%#Downloading%.%#,
+            \%-G%\\s%#Checking%.%#,
             \%-G%\\s%#Compiling%.%#,
             \%-G%\\s%#Finished%.%#,
             \%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
             \%-G%\\s%#To\ learn\ more\\,%.%#,
+            \%-G%\\s%#For\ more\ information\ about\ this\ error\\,%.%#,
             \%-Gerror:\ test\ failed\\,\ to\ rerun\ pass%.%#,
             \%-Gnote:\ Run\ with\ \`RUST_BACKTRACE=%.%#,
             \%.%#panicked\ at\ \\'%m\\'\\,\ %f:%l:%c

--- a/compiler/cargo.vim
+++ b/compiler/cargo.vim
@@ -39,6 +39,7 @@ CompilerSet errorformat+=
             \%-G%\\s%#error:\ Could\ not\ compile\ %.%#,
             \%-G%\\s%#To\ learn\ more\\,%.%#,
             \%-Gnote:\ Run\ with\ \`RUST_BACKTRACE=%.%#,
+            \%-Gnote:\ run\ with\ \`RUST_BACKTRACE=%.%#,
             \%.%#panicked\ at\ \\'%m\\'\\,\ %f:%l:%c
 
 " vint: -ProhibitAbbreviationOption


### PR DESCRIPTION
Rust compiler output
```
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
did not ignored due to errorformat was set `\%Inote:\ %m` first.
So, change `+=` to `^=` solve this problem.

And, more `cargo test` cmmand output `error: test failed, to rerun pass ...` should be ignored.

I wish this change would apply to vim repository.
In vim repository,  `compiler/cargo.vim` is not up-to-date, so we cannot parse error correctly.