### PR TITLE
Allow option to highlight operator `as` as keyword

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -26,7 +26,7 @@ syn keyword   rustTypedef type nextgroup=rustIdentifier skipwhite skipempty
 syn keyword   rustStructure struct enum nextgroup=rustIdentifier skipwhite skipempty
 syn keyword   rustUnion union nextgroup=rustIdentifier skipwhite skipempty contained
 syn match rustUnionContextual /\<union\_s\+\%([^[:cntrl:][:space:][:punct:][:digit:]]\|_\)\%([^[:cntrl:][:punct:][:space:]]\|_\)*/ transparent contains=rustUnion
-syn keyword   rustOperator    as
+syn keyword   rustOperatorKeyword as
 syn keyword   rustExistential existential nextgroup=rustTypedef skipwhite skipempty contained
 syn match rustExistentialContextual /\<existential\_s\+type/ transparent contains=rustExistential,rustTypedef
 
@@ -321,6 +321,7 @@ hi def link rustFloat         Float
 hi def link rustArrowCharacter rustOperator
 hi def link rustOperator      Operator
 hi def link rustKeyword       Keyword
+hi def link rustOperatorKeyword rustOperator
 hi def link rustDynKeyword    rustKeyword
 hi def link rustTypedef       Keyword " More precise is Typedef, but it doesn't feel right for Rust
 hi def link rustStructure     Keyword " More precise is Structure


### PR DESCRIPTION
While `as` is functionally an operator, it is often highlighted as if it were a keyword. This change gives the user the option to link `rustOperatorKeyword` to `Keyword` while preserving the current default behavior. This allows for `as` to be highlighted like a keyword separately from other operators.

The documentation lists `as` as a keyword and consistently highlights it as such.

https://doc.rust-lang.org/std/index.html#keywords
https://doc.rust-lang.org/std/keyword.as.html