### PR TITLE
Migrate from highfive to triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,1 +1,4 @@
 [assign]
+
+[assign.owners]
+"*" = ["@chris-morgan", "@da-x"]


### PR DESCRIPTION
This migrates this repository from using the highfive bot to using triagebot (aka rustbot).

This is ready to merge now, feel free to merge to re-enable auto-assignment.
