### PR TITLE
Respect no_plugin_maps/no_rust_maps settings

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -95,13 +95,15 @@ endif
 
 " Motion Commands {{{1
 
-" Bind motion commands to support hanging indents
-nnoremap <silent> <buffer> [[ :call rust#Jump('n', 'Back')<CR>
-nnoremap <silent> <buffer> ]] :call rust#Jump('n', 'Forward')<CR>
-xnoremap <silent> <buffer> [[ :call rust#Jump('v', 'Back')<CR>
-xnoremap <silent> <buffer> ]] :call rust#Jump('v', 'Forward')<CR>
-onoremap <silent> <buffer> [[ :call rust#Jump('o', 'Back')<CR>
-onoremap <silent> <buffer> ]] :call rust#Jump('o', 'Forward')<CR>
+if !exists('g:no_plugin_maps') && !exists('g:no_rust_maps')
+    " Bind motion commands to support hanging indents
+    nnoremap <silent> <buffer> [[ :call rust#Jump('n', 'Back')<CR>
+    nnoremap <silent> <buffer> ]] :call rust#Jump('n', 'Forward')<CR>
+    xnoremap <silent> <buffer> [[ :call rust#Jump('v', 'Back')<CR>
+    xnoremap <silent> <buffer> ]] :call rust#Jump('v', 'Forward')<CR>
+    onoremap <silent> <buffer> [[ :call rust#Jump('o', 'Back')<CR>
+    onoremap <silent> <buffer> ]] :call rust#Jump('o', 'Forward')<CR>
+endif
 
 " Commands {{{1
 


### PR DESCRIPTION
I noticed that the rust ftplugin does not respect `no_rust_maps` or `no_plugin_maps` and just sets keymaps unconditionally.  Many other filetype plugins do this and it is also documented in the [official docs](https://github.com/vim/vim/blob/0c98a71236e6eca983fed5d903d07bd53190d16b/runtime/doc/filetype.txt#L386).

This PR adds a check to see if one of the variables is set.