### PR TITLE
Support C string literals highlight

### DIFF
--- a/syntax/rust.vim
+++ b/syntax/rust.vim
@@ -145,9 +145,9 @@ syn match     rustEscapeError   display contained /\\./
 syn match     rustEscape        display contained /\\\([nrt0\\'"]\|x\x\{2}\)/
 syn match     rustEscapeUnicode display contained /\\u{\%(\x_*\)\{1,6}}/
 syn match     rustStringContinuation display contained /\\\n\s*/
-syn region    rustString      matchgroup=rustStringDelimiter start=+b"+ skip=+\\\\\|\\"+ end=+"+ contains=rustEscape,rustEscapeError,rustStringContinuation
+syn region    rustString      matchgroup=rustStringDelimiter start=+[bc]"+ skip=+\\\\\|\\"+ end=+"+ contains=rustEscape,rustEscapeError,rustStringContinuation
 syn region    rustString      matchgroup=rustStringDelimiter start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=rustEscape,rustEscapeUnicode,rustEscapeError,rustStringContinuation,@Spell
-syn region    rustString      matchgroup=rustStringDelimiter start='b\?r\z(#*\)"' end='"\z1' contains=@Spell
+syn region    rustString      matchgroup=rustStringDelimiter start='[bc]\?r\z(#*\)"' end='"\z1' contains=@Spell
 
 " Match attributes with either arbitrary syntax or special highlighting for
 " derives. We still highlight strings and comments inside of the attribute.


### PR DESCRIPTION
Recently Rust [has stabilized C string literals](https://github.com/rust-lang/rust/pull/117472)  syntax ([the tracking issue](https://github.com/rust-lang/rust/issues/105723)). It will be available on the stable toolchain soon.

```rust
const HELLO: &core::ffi::CStr = c"Hello, world!";
const HELLO: &core::ffi::CStr = cr#"Hello, world!"#;
```

This PR adds support for the syntax.

Before:

<img width="444" alt="image" src="https://github.com/rust-lang/rust.vim/assets/823277/b566a96c-f38a-4157-9968-d25fe6d7dfb3">

After:

<img width="434" alt="image" src="https://github.com/rust-lang/rust.vim/assets/823277/68b7a0f7-babd-4df7-9955-558142431d00">
