### PR TITLE
Include space in commentstring

### DIFF
--- a/ftplugin/rust.vim
+++ b/ftplugin/rust.vim
@@ -36,7 +36,7 @@ if get(g:, 'rust_bang_comment_leader', 0)
 else
     setlocal comments=s0:/*!,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
 endif
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 setlocal formatoptions-=t formatoptions+=croqnl
 " j was only added in 7.3.541, so stop complaints about its nonexistence
 silent! setlocal formatoptions+=j


### PR DESCRIPTION
The rust style guide recommends putting a space after the `//` and this style is also the most commonly used one in the rust compiler itself