### PR TITLE
add a option to disable rustfmt

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -2,6 +2,17 @@
 "
 " Adapted from https://github.com/fatih/vim-go
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
+if exists("g:rustfmt_loaded")
+  finish
+endif
+let g:rustfmt_loaded = 1
+
+
+if exists("g:rustfmt_disable")
+    if g:rustfmt_disable
+        finish
+    endif
+endif
 
 if !exists("g:rustfmt_autosave")
     let g:rustfmt_autosave = 0

--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -110,7 +110,12 @@ g:ftplugin_rust_source_path~
 	source files: >
 	    let g:ftplugin_rust_source_path = $HOME.'/dev/rust'
 <
-
+                                                       *g:rustfmt_disable*
+g:rustfmt_disable~
+	Set this option to disable rustfmt function. If not specified it 
+	defaults to 0 : >
+	    let g:rustfmt_disable = 0
+<
                                                        *g:rustfmt_command*
 g:rustfmt_command~
 	Set this option to the name of the 'rustfmt' executable in your $PATH. If


### PR DESCRIPTION
I would like to format code with LSP.
And  rustfmt.vim will block vim when I save the file even g:rustfmt_autosave is set to 0.

```
FUNCTION  rustfmt#DetectVersion()
    Defined: D:\vim\rust.vim\autoload\rustfmt.vim:22
Called 1 time
Total time:   4.867242
 Self time:   0.002583

count  total (s)   self (s)
                                " Save rustfmt '--help' for feature inspection
    1   2.422317   0.001164     silent let s:rustfmt_help = system(g:rustfmt_command . " --help")
    1              0.000025     let s:rustfmt_unstable_features = s:rustfmt_help =~# "--unstable-features"
                            
                                " Build a comparable rustfmt version varible out of its `--version` output:
    1   2.444845   0.001339     silent let l:rustfmt_version_full = system(g:rustfmt_command . " --version")
    1              0.000033     let l:rustfmt_version_list = matchlist(l:rustfmt_version_full,    '\vrustfmt ([0-9]+[.][0-9]+[.][0-9]+)')
    1              0.000005     if len(l:rustfmt_version_list) < 3
    1              0.000003         let s:rustfmt_version = "0"
                                else
                                    let s:rustfmt_version = l:rustfmt_version_list[1]
    1              0.000001     endif
    1              0.000002     return s:rustfmt_version
```