### PR TITLE
Add support for reading rustfmt.toml from $HOMEDIR

### DIFF
--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -61,6 +61,16 @@ function! s:RustfmtWriteMode()
 endfunction
 
 function! s:RustfmtConfigOptions()
+    let l:rustfmt_toml = findfile('rustfmt.toml', expand('%:p:h') . ';')
+    if l:rustfmt_toml !=# ''
+        return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
+    endif
+
+    let l:_rustfmt_toml = findfile('.rustfmt.toml', expand('%:p:h') . ';')
+    if l:_rustfmt_toml !=# ''
+        return '--config-path '.shellescape(fnamemodify(l:_rustfmt_toml, ":p"))
+    endif
+
     let l:rustfmt_toml = findfile(expand('$HOME/rustfmt.toml'), expand('%:p:h') . ';')
     if l:rustfmt_toml !=# ''
         return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
@@ -79,16 +89,6 @@ function! s:RustfmtConfigOptions()
     let l:rustfmt_toml = findfile(expand('$HOME/.config/rustfmt/.rustfmt.toml'), expand('%:p:h') . ';')
     if l:rustfmt_toml !=# ''
         return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
-    endif
-
-    let l:rustfmt_toml = findfile('rustfmt.toml', expand('%:p:h') . ';')
-    if l:rustfmt_toml !=# ''
-        return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
-    endif
-
-    let l:_rustfmt_toml = findfile('.rustfmt.toml', expand('%:p:h') . ';')
-    if l:_rustfmt_toml !=# ''
-        return '--config-path '.shellescape(fnamemodify(l:_rustfmt_toml, ":p"))
     endif
 
     " Default to edition 2018 in case no rustfmt.toml was found.

--- a/autoload/rustfmt.vim
+++ b/autoload/rustfmt.vim
@@ -61,6 +61,26 @@ function! s:RustfmtWriteMode()
 endfunction
 
 function! s:RustfmtConfigOptions()
+    let l:rustfmt_toml = findfile(expand('$HOME/rustfmt.toml'), expand('%:p:h') . ';')
+    if l:rustfmt_toml !=# ''
+        return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
+    endif
+
+    let l:rustfmt_toml = findfile(expand('$HOME/.rustfmt.toml'), expand('%:p:h') . ';')
+    if l:rustfmt_toml !=# ''
+        return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
+    endif
+
+    let l:rustfmt_toml = findfile(expand('$HOME/.config/rustfmt/rustfmt.toml'), expand('%:p:h') . ';')
+    if l:rustfmt_toml !=# ''
+        return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
+    endif
+
+    let l:rustfmt_toml = findfile(expand('$HOME/.config/rustfmt/.rustfmt.toml'), expand('%:p:h') . ';')
+    if l:rustfmt_toml !=# ''
+        return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
+    endif
+
     let l:rustfmt_toml = findfile('rustfmt.toml', expand('%:p:h') . ';')
     if l:rustfmt_toml !=# ''
         return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))


### PR DESCRIPTION
Mimicks rustfmt standard behaviour and after searching through project files for rustfmt.toml, it also tries $HOMEDIR and $HOMEDIR/.config/rustfmt/, as per [config/mod.rs](https://github.com/rust-lang/rustfmt/blob/777e25a8c91af9923ad356eb4448ac2ed15167a9/src/config/mod.rs#L307).
Current :RustFmt behavior forces `--edition 2018` when rustfmt.toml is not found in project directory.