### PR TITLE
autoload/rustfmt.vim slowdown vim startup

### DIFF
--- a/doc/rust.txt
+++ b/doc/rust.txt
@@ -152,13 +152,40 @@ g:rustfmt_options~
 	defaults to '' : >
 	    let g:rustfmt_options = ''
 <
-                                                       *g:rustfmt_emit_files*
-g:rustfmt_emit_files~
-	If not specified rust.vim tries to detect the right parameter to
-	pass to rustfmt based on its reported version. Otherwise, it
-	determines whether to run rustfmt with '--emit=files' (when 1 is
-	provided) instead of '--write-mode=overwrite'. >
-	    let g:rustfmt_emit_files = 0
+
+                                                   *g:rustfmt_emitmode_legacy*
+g:rustfmt_emitmode_legacy~
+	Set this option to 1 if the `rustfmt` version is smaller than 0.8.2.
+	defaults to 0 : >
+	    let g:rustfmt_emitmode_legacy = 0
+<
+	NOTE: If set to 0, run `rustfmt` with '--emit=files', else run it with
+	'--write-mode=overwrite'. (From 0.8.2, `rustfmt` change the option
+	'write-mode' to 'emit'.)
+
+
+                                                      *g:rustfmt_format_range*
+g:rustfmt_format_range~
+	Set this option to 1 to format only a range of a file. (Reference
+	from `rustfmt` doc)
+	defaults to 0 : >
+	    let g:rustfmt_format_range = 0
+<
+	NOTE: This feature only work on 'nightly' version currently, cause
+	it depends on option 'file-lines', and 'file-lines' depends on
+	option 'unstable-features', and 'unstable-features' only work on
+	'nightly' version.
+
+
+                                                    *g:rustfmt_use_configfile*
+g:rustfmt_use_configfile~
+	Set this option t 1 to use `rustfmt` configuration file `rustfmt.toml`
+	or `.rustfmt.toml` (Reference from `rustfmt` doc).
+	defaults to 0 : >
+	    let g:rustfmt_use_configfile = 0
+<
+	NOTE: If this option set to 0, will using the default option
+	`--edition 2018`.
 
 
                                                           *g:rust_playpen_url*


### PR DESCRIPTION
fix #524

`rustfmt.vim` want to switch config option automatically between difference `rustfmt` version according detect version and check supported option of `rustfmt`. But this design causing more trouble than convenience for users.

According this change, we not need to call `rustfmt --version` and `rustfmt --help` anymore. If we need to support new feature:

1. for breaking change compatible, providing option `g:rustfmt_xxx_legacy`
2. for new `rustfmt` option and it can't be config in configuration file, providing option `g:rustfmt_xxx_xxx`. We don't care about it is `nightly` or `stable`, we just make sure: If it is `nightly` only, then it work on `nightly` version. If it is both, then it work on both. That is it.
3. other should be done by `g:rustfmt_use_configfile`. If set to 1, using config file; otherwise using default (current is `--edition 2018`).


more details in [this comment](https://github.com/vim/vim/issues/17745#issuecomment-3072060411) and [relative issue in vim](https://github.com/vim/vim/issues/17745)
